### PR TITLE
Check existence of inbox before cleaning for when client connecting with CleanStart=True

### DIFF
--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/BaseMQTTTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/BaseMQTTTest.java
@@ -425,7 +425,7 @@ public abstract class BaseMQTTTest {
     protected void setupTransientSession() {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
         channel.runPendingTasks();

--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTT3ConnectHandlerTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTT3ConnectHandlerTest.java
@@ -14,7 +14,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License.    
+ * under the License.
  */
 
 package org.apache.bifromq.mqtt.handler.v3;
@@ -30,9 +30,22 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.apache.bifromq.inbox.client.IInboxClient;
 import org.apache.bifromq.inbox.rpc.proto.AttachReply;
 import org.apache.bifromq.inbox.rpc.proto.DetachReply;
+import org.apache.bifromq.inbox.rpc.proto.ExistReply;
 import org.apache.bifromq.mqtt.MockableTest;
 import org.apache.bifromq.mqtt.handler.ChannelAttrs;
 import org.apache.bifromq.mqtt.handler.v5.MQTT5MessageUtils;
@@ -49,22 +62,10 @@ import org.apache.bifromq.plugin.clientbalancer.Redirection;
 import org.apache.bifromq.plugin.eventcollector.EventType;
 import org.apache.bifromq.plugin.eventcollector.IEventCollector;
 import org.apache.bifromq.plugin.eventcollector.mqttbroker.clientdisconnect.Redirect;
+import org.apache.bifromq.plugin.resourcethrottler.IResourceThrottler;
 import org.apache.bifromq.plugin.settingprovider.ISettingProvider;
 import org.apache.bifromq.plugin.settingprovider.Setting;
 import org.apache.bifromq.type.ClientInfo;
-import org.apache.bifromq.plugin.resourcethrottler.IResourceThrottler;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.mqtt.MqttConnAckMessage;
-import io.netty.handler.codec.mqtt.MqttConnectMessage;
-import io.netty.handler.codec.mqtt.MqttMessageBuilders;
-import io.netty.handler.codec.mqtt.MqttVersion;
-import java.net.InetSocketAddress;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -229,6 +230,9 @@ public class MQTT3ConnectHandlerTest extends MockableTest {
         when(authProvider.checkPermission(any(ClientInfo.class), argThat(MQTTAction::hasConn))).thenReturn(
             CompletableFuture.completedFuture(
                 CheckResult.newBuilder().setGranted(Granted.getDefaultInstance()).build()));
+        when(inboxClient.exist(any())).thenReturn(CompletableFuture.completedFuture(ExistReply.newBuilder()
+            .setCode(ExistReply.Code.EXIST)
+            .build()));
         when(inboxClient.detach(any())).thenReturn(CompletableFuture.completedFuture(DetachReply.newBuilder()
             .setCode(DetachReply.Code.BACK_PRESSURE_REJECTED)
             .build()));

--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTConnectTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTConnectTest.java
@@ -59,7 +59,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
     public void transientSessionWithoutInbox() {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
         channel.runPendingTasks();
@@ -72,6 +72,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
     public void transientSessionWithInbox() {
         mockAuthPass();
         mockSessionReg();
+        mockInboxExist(true);
         mockInboxDetach(DetachReply.Code.OK);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
@@ -86,6 +87,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
         // clear failed
         mockAuthPass();
         mockSessionReg();
+        mockInboxExist(true);
         mockInboxDetach(DetachReply.Code.ERROR);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
@@ -161,6 +163,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
         String attrVal = "attrVal";
         mockAuthPass(attrKey, attrVal);
         mockSessionReg();
+        mockInboxExist(true);
         mockInboxDetach(DetachReply.Code.OK);
 
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
@@ -183,6 +186,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
         String attrVal = "attrVal";
         mockAuthPass(attrKey, attrVal);
         mockSessionReg();
+        mockInboxExist(true);
         mockInboxDetach(DetachReply.Code.OK);
 
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
@@ -191,7 +195,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
         channel.runPendingTasks();
         MqttConnAckMessage ackMessage = channel.readOutbound();
         // verifications
-        Assert.assertEquals(CONNECTION_ACCEPTED, ackMessage.variableHeader().connectReturnCode());
+        Assert.assertEquals(ackMessage.variableHeader().connectReturnCode(), CONNECTION_ACCEPTED);
         ArgumentCaptor<ClientConnected> eventArgumentCaptor = ArgumentCaptor.forClass(ClientConnected.class);
         verify(eventCollector).report(eventArgumentCaptor.capture());
         ClientConnected clientConnected = eventArgumentCaptor.getValue();
@@ -208,7 +212,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
         channel.runPendingTasks();
         MqttConnAckMessage ackMessage = channel.readOutbound();
         // verifications
-        Assert.assertEquals(CONNECTION_REFUSED_NOT_AUTHORIZED, ackMessage.variableHeader().connectReturnCode());
+        Assert.assertEquals(ackMessage.variableHeader().connectReturnCode(), CONNECTION_REFUSED_NOT_AUTHORIZED);
         verifyEvent(EventType.NOT_AUTHORIZED_CLIENT);
     }
 
@@ -221,8 +225,8 @@ public class MQTTConnectTest extends BaseMQTTTest {
         channel.advanceTimeBy(disconnectDelay, TimeUnit.MILLISECONDS);
         channel.runPendingTasks();
         MqttConnAckMessage ackMessage = channel.readOutbound();
-        Assert.assertEquals(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD,
-            ackMessage.variableHeader().connectReturnCode());
+        Assert.assertEquals(ackMessage.variableHeader().connectReturnCode(),
+                CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
         verifyEvent(EventType.UNAUTHENTICATED_CLIENT);
     }
 
@@ -245,6 +249,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
     public void validWillTopic() {
         mockAuthPass();
         mockSessionReg();
+        mockInboxExist(true);
         mockInboxDetach(DetachReply.Code.OK);
         MqttConnectMessage connectMessage = MQTTMessageUtils.qoSWillMqttConnectMessage(1, true);
         channel.writeInbound(connectMessage);
@@ -258,6 +263,7 @@ public class MQTTConnectTest extends BaseMQTTTest {
     public void pingAndPingResp() {
         mockAuthPass();
         mockSessionReg();
+        mockInboxExist(true);
         mockInboxDetach(DetachReply.Code.OK);
         MqttConnectMessage connectMessage = MQTTMessageUtils.qoSWillMqttConnectMessage(1, true);
         channel.writeInbound(connectMessage);

--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTDisconnectTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTDisconnectTest.java
@@ -50,6 +50,7 @@ public class MQTTDisconnectTest extends BaseMQTTTest {
     public void transientSession() {
         mockAuthPass();
         mockSessionReg();
+        mockInboxExist(true);
         mockInboxDetach(DetachReply.Code.OK);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
@@ -86,7 +87,7 @@ public class MQTTDisconnectTest extends BaseMQTTTest {
     public void idle() {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true, "testClientId", 60);
         channel.writeInbound(connectMessage);
         channel.runPendingTasks();
@@ -102,7 +103,7 @@ public class MQTTDisconnectTest extends BaseMQTTTest {
     public void noKeepAlive() {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
 
         // keepalive = 0
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true, "abc", 0);
@@ -121,7 +122,7 @@ public class MQTTDisconnectTest extends BaseMQTTTest {
     public void enforceMinKeepAlive() {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
 
         // keepalive too short, least is 60s
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true, "abc", 1);
@@ -139,7 +140,7 @@ public class MQTTDisconnectTest extends BaseMQTTTest {
     public void connectTwice() {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
         channel.runPendingTasks();
@@ -156,6 +157,7 @@ public class MQTTDisconnectTest extends BaseMQTTTest {
     public void disconnectByServer() {
         mockAuthPass();
         mockSessionReg();
+        mockInboxExist(true);
         mockInboxDetach(DetachReply.Code.NO_INBOX);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
@@ -171,7 +173,7 @@ public class MQTTDisconnectTest extends BaseMQTTTest {
     public void badPacketAfterConnected() {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
         channel.runPendingTasks();

--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTKickTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTKickTest.java
@@ -27,7 +27,6 @@ import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEP
 
 import io.netty.handler.codec.mqtt.MqttConnAckMessage;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
-import org.apache.bifromq.inbox.rpc.proto.DetachReply;
 import org.apache.bifromq.mqtt.utils.MQTTMessageUtils;
 import org.apache.bifromq.sessiondict.rpc.proto.ServerRedirection;
 import org.apache.bifromq.type.ClientInfo;
@@ -40,11 +39,11 @@ public class MQTTKickTest extends BaseMQTTTest {
     public void testKick() {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
         MqttConnectMessage connectMessage = MQTTMessageUtils.mqttConnectMessage(true);
         channel.writeInbound(connectMessage);
         MqttConnAckMessage ackMessage = channel.readOutbound();
-        Assert.assertEquals(CONNECTION_ACCEPTED, ackMessage.variableHeader().connectReturnCode());
+        Assert.assertEquals(ackMessage.variableHeader().connectReturnCode(), CONNECTION_ACCEPTED);
 
         // kick
 

--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTWillMessageTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTWillMessageTest.java
@@ -14,12 +14,13 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License.    
+ * under the License.
  */
 
 package org.apache.bifromq.mqtt.handler.v3;
 
 
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
 import static org.apache.bifromq.plugin.eventcollector.EventType.CLIENT_CONNECTED;
 import static org.apache.bifromq.plugin.eventcollector.EventType.IDLE;
 import static org.apache.bifromq.plugin.eventcollector.EventType.KICKED;
@@ -34,7 +35,6 @@ import static org.apache.bifromq.plugin.eventcollector.EventType.WILL_DIST_ERROR
 import static org.apache.bifromq.retain.rpc.proto.RetainReply.Result.CLEARED;
 import static org.apache.bifromq.retain.rpc.proto.RetainReply.Result.ERROR;
 import static org.apache.bifromq.retain.rpc.proto.RetainReply.Result.RETAINED;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -42,13 +42,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 
-import org.apache.bifromq.plugin.eventcollector.EventType;
 import io.netty.handler.codec.mqtt.MqttConnAckMessage;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bifromq.inbox.rpc.proto.DetachReply;
 import org.apache.bifromq.mqtt.utils.MQTTMessageUtils;
+import org.apache.bifromq.plugin.eventcollector.EventType;
 import org.apache.bifromq.sessiondict.rpc.proto.ServerRedirection;
 import org.apache.bifromq.type.ClientInfo;
 import org.testng.Assert;
@@ -189,7 +188,7 @@ public class MQTTWillMessageTest extends BaseMQTTTest {
     protected void setupTransientSessionWithLWT(boolean willRetain) {
         mockAuthPass();
         mockSessionReg();
-        mockInboxDetach(DetachReply.Code.NO_INBOX);
+        mockInboxExist(false);
         MqttConnectMessage connectMessage;
         if (!willRetain) {
             connectMessage = MQTTMessageUtils.qoSWillMqttConnectMessage(1, true);

--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v5/MQTT5ConnectHandlerTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v5/MQTT5ConnectHandlerTest.java
@@ -371,6 +371,9 @@ public class MQTT5ConnectHandlerTest extends MockableTest {
         when(authProvider.checkPermission(any(ClientInfo.class), argThat(MQTTAction::hasConn))).thenReturn(
             CompletableFuture.completedFuture(
                 CheckResult.newBuilder().setGranted(Granted.getDefaultInstance()).build()));
+        when(inboxClient.exist(any())).thenReturn(CompletableFuture.completedFuture(ExistReply.newBuilder()
+                .setCode(ExistReply.Code.EXIST)
+                .build()));
         when(inboxClient.detach(any())).thenReturn(CompletableFuture.completedFuture(DetachReply.newBuilder()
             .setCode(DetachReply.Code.BACK_PRESSURE_REJECTED)
             .build()));


### PR DESCRIPTION
The "CleanStart = true" with a non-empty client ID requires clearing the previous session, which may trigger a write to the inbox store regardless of whether a previous session actually exists. To reduce unnecessary overhead, we can first check for the existence of the session—a lightweight read—and only perform the clear operation if necessary. This approach can significantly reduce inbox store overhead in typical scenarios.