### PR TITLE
Resolve the issue of LOG_DIR environment variable not working

### DIFF
--- a/build/build-bifromq-starter/bin/standalone.bat
+++ b/build/build-bifromq-starter/bin/standalone.bat
@@ -27,7 +27,7 @@ set BIN_DIR=%~dp0
 for %%i in ("%BIN_DIR%\..") do (
   set BASE_DIR=%%~fi
 )
-set LOG_DIR=%BASE_DIR%\logs
+
 set SCRIPT=%0
 set COMMAND=%1
 set FOREGROUND=%2

--- a/build/build-bifromq-starter/bin/standalone.sh
+++ b/build/build-bifromq-starter/bin/standalone.sh
@@ -23,7 +23,6 @@ BASE_DIR=$(
   cd "$(dirname "$0")"
   pwd
 )/..
-export LOG_DIR=$BASE_DIR/logs
 
 if [ $# -lt 1 ]; then
   echo "USAGE: $0 {start|stop|restart} [-fg]"


### PR DESCRIPTION
The 'export LOG-DIR=$BASE-DIR/logs' in standalone. sh will overwrite the external LOG-DIR environment variable, causing it to not work