### PR TITLE
move the position of "mqtt.tsub.latency" measured to the MQTTransient…

### DIFF
--- a/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/handler/MQTTSessionHandler.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/handler/MQTTSessionHandler.java
@@ -33,7 +33,6 @@ import static org.apache.bifromq.metrics.TenantMetric.MqttQoS2DeliverBytes;
 import static org.apache.bifromq.metrics.TenantMetric.MqttQoS2DistBytes;
 import static org.apache.bifromq.metrics.TenantMetric.MqttQoS2ExternalLatency;
 import static org.apache.bifromq.metrics.TenantMetric.MqttQoS2IngressBytes;
-import static org.apache.bifromq.metrics.TenantMetric.MqttTransientSubLatency;
 import static org.apache.bifromq.mqtt.handler.IMQTTProtocolHelper.SubResult.EXCEED_LIMIT;
 import static org.apache.bifromq.mqtt.handler.MQTTSessionIdUtil.packetId;
 import static org.apache.bifromq.mqtt.handler.MQTTSessionIdUtil.userSessionId;
@@ -570,12 +569,10 @@ public abstract class MQTTSessionHandler extends MQTTMessageHandler implements I
                             .setUserProperties(grantedUserProps);
                         subTask.subId().ifPresent(optionBuilder::setSubId);
                         TopicFilterOption tfOption = optionBuilder.build();
-                        Timer.Sample start = Timer.start();
                         return addFgTask(subTopicFilter(reqId, topicFilter, tfOption))
                             .thenComposeAsync(subResult -> {
                                 switch (subResult) {
                                     case OK, EXISTS -> {
-                                        start.stop(tenantMeter.timer(MqttTransientSubLatency));
                                         if (!isSharedSubscription(topicFilter) && settings.retainEnabled
                                             && (tfOption.getRetainHandling() == SEND_AT_SUBSCRIBE
                                             || (subResult == IMQTTProtocolHelper.SubResult.OK

--- a/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/handler/MQTTTransientSessionHandler.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/handler/MQTTTransientSessionHandler.java
@@ -23,6 +23,7 @@ import static org.apache.bifromq.metrics.TenantMetric.MqttQoS0InternalLatency;
 import static org.apache.bifromq.metrics.TenantMetric.MqttQoS1InternalLatency;
 import static org.apache.bifromq.metrics.TenantMetric.MqttQoS2InternalLatency;
 import static org.apache.bifromq.metrics.TenantMetric.MqttTransientSubCount;
+import static org.apache.bifromq.metrics.TenantMetric.MqttTransientSubLatency;
 import static org.apache.bifromq.metrics.TenantMetric.MqttTransientUnsubCount;
 import static org.apache.bifromq.metrics.TenantMetric.MqttTransientUnsubLatency;
 import static org.apache.bifromq.mqtt.handler.IMQTTProtocolHelper.SubResult.EXCEED_LIMIT;
@@ -181,10 +182,12 @@ public abstract class MQTTTransientSessionHandler extends MQTTSessionHandler imp
             memUsage.addAndGet(topicFilter.length());
             memUsage.addAndGet(option.getSerializedSize());
         }
+        Timer.Sample start = Timer.start();
         return addMatchRecord(reqId, topicFilter, option.getIncarnation())
             .thenApplyAsync(matchResult -> {
                 switch (matchResult) {
                     case OK -> {
+                        start.stop(tenantMeter.timer(MqttTransientSubLatency));
                         if (prevOption == null) {
                             return OK;
                         } else {


### PR DESCRIPTION
Fixes #174 

move the position of "mqtt.tsub.latency" measured to the MQTTransientSessionHandler class for non-persistent sessions only