### PR TITLE
Improved tenant route cache refresh efficiency

### DIFF
--- a/bifromq-dist/bifromq-dist-worker-schema/pom.xml
+++ b/bifromq-dist/bifromq-dist-worker-schema/pom.xml
@@ -31,6 +31,10 @@
     <artifactId>bifromq-dist-worker-schema</artifactId>
     <dependencies>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.bifromq</groupId>
             <artifactId>bifromq-util</artifactId>
         </dependency>

--- a/bifromq-dist/bifromq-dist-worker-schema/src/main/java/org/apache/bifromq/dist/worker/schema/GroupMatching.java
+++ b/bifromq-dist/bifromq-dist-worker-schema/src/main/java/org/apache/bifromq/dist/worker/schema/GroupMatching.java
@@ -29,7 +29,7 @@ import org.apache.bifromq.type.RouteMatcher;
 /**
  * Represent a group matching route.
  */
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY)
 @ToString
 public final class GroupMatching extends Matching {
     @EqualsAndHashCode.Exclude
@@ -41,8 +41,9 @@ public final class GroupMatching extends Matching {
     GroupMatching(String tenantId, RouteMatcher matcher, Map<String, Long> members) {
         super(tenantId, matcher);
         assert matcher.getType() != RouteMatcher.Type.Normal;
-        this.ordered = matcher.getType() == RouteMatcher.Type.OrderedShare;
         this.receivers = members;
+
+        this.ordered = matcher.getType() == RouteMatcher.Type.OrderedShare;
         this.receiverList = members.entrySet().stream()
             .map(e -> new NormalMatching(tenantId, matcher, e.getKey(), e.getValue()))
             .collect(Collectors.toList());

--- a/bifromq-dist/bifromq-dist-worker-schema/src/main/java/org/apache/bifromq/dist/worker/schema/NormalMatching.java
+++ b/bifromq-dist/bifromq-dist-worker-schema/src/main/java/org/apache/bifromq/dist/worker/schema/NormalMatching.java
@@ -27,7 +27,7 @@ import org.apache.bifromq.type.RouteMatcher;
 /**
  * Represent a normal matching route.
  */
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY)
 @ToString
 public class NormalMatching extends Matching {
     private final String receiverUrl;

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/IMatchedRoutes.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/IMatchedRoutes.java
@@ -20,10 +20,12 @@
 package org.apache.bifromq.dist.worker.cache;
 
 import java.util.Set;
+import org.apache.bifromq.dist.worker.schema.GroupMatching;
 import org.apache.bifromq.dist.worker.schema.Matching;
+import org.apache.bifromq.dist.worker.schema.NormalMatching;
 
 /**
- * The result of matching a topic within a boundary.
+ * A mutable matched routes for a topic.
  */
 public interface IMatchedRoutes {
     /**
@@ -61,4 +63,51 @@ public interface IMatchedRoutes {
      */
     Set<Matching> routes();
 
+    /**
+     * Add a normal matching to the matched routes.
+     *
+     * @param matching the normal matching to add
+     */
+    AddResult addNormalMatching(NormalMatching matching);
+
+    /**
+     * Remove a normal matching from the matched routes.
+     *
+     * @param matching the normal matching to remove
+     */
+    void removeNormalMatching(NormalMatching matching);
+
+    /**
+     * Add a new or override an existing group matching to the matched routes.
+     *
+     * @param matching the group matching to add or override
+     */
+    AddResult putGroupMatching(GroupMatching matching);
+
+    /**
+     * Remove an existing group matching.
+     *
+     * @param matching the group matching to remove
+     */
+    void removeGroupMatching(GroupMatching matching);
+
+    /**
+     * Adjust matched routes to new fanout limits. If the current fanout exceeds the new limits, the matched routes
+     * will be clamped to the new limits by removing excess persistent fanout matchings.
+     * If the new limits are higher than the previous and the current fanout is already at the previous limits,
+     * ReloadNeeded is returned.
+     *
+     * @param newMaxPersistentFanout the new maximum persistent fanout
+     * @param newMaxGroupFanout the new maximum group fanout
+     * @return the adjust result
+     */
+    AdjustResult adjust(int newMaxPersistentFanout, int newMaxGroupFanout);
+
+    enum AdjustResult {
+        Clamped, Adjusted, ReloadNeeded
+    }
+
+    enum AddResult {
+        Added, Exists, ExceedFanoutLimit
+    }
 }

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/ISubscriptionCache.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/ISubscriptionCache.java
@@ -14,26 +14,25 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License.    
+ * under the License.
  */
 
 package org.apache.bifromq.dist.worker.cache;
 
-import org.apache.bifromq.basekv.proto.Boundary;
-import org.apache.bifromq.dist.worker.schema.Matching;
-import org.apache.bifromq.type.RouteMatcher;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import org.apache.bifromq.basekv.proto.Boundary;
+import org.apache.bifromq.dist.worker.cache.task.RefreshEntriesTask;
+import org.apache.bifromq.dist.worker.schema.Matching;
 
 public interface ISubscriptionCache {
     CompletableFuture<Set<Matching>> get(String tenantId, String topic);
 
     boolean isCached(String tenantId, List<String> filterLevels);
 
-    void refresh(Map<String, NavigableSet<RouteMatcher>> topicFiltersByTenant);
+    void refresh(Map<String, RefreshEntriesTask> tenantRefreshTasks);
 
     void reset(Boundary boundary);
 

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/MatchedRoutes.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/MatchedRoutes.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bifromq.dist.worker.cache;
+
+import static org.apache.bifromq.plugin.eventcollector.ThreadLocalEventPool.getLocal;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.bifromq.dist.worker.schema.GroupMatching;
+import org.apache.bifromq.dist.worker.schema.Matching;
+import org.apache.bifromq.dist.worker.schema.NormalMatching;
+import org.apache.bifromq.plugin.eventcollector.IEventCollector;
+import org.apache.bifromq.plugin.eventcollector.distservice.GroupFanoutThrottled;
+import org.apache.bifromq.plugin.eventcollector.distservice.PersistentFanoutThrottled;
+
+public class MatchedRoutes implements IMatchedRoutes {
+    private final String tenantId;
+    private final String topic;
+    private final IEventCollector eventCollector;
+    private final Set<Matching> allMatchings = Sets.newConcurrentHashSet();
+    private final Map<String, GroupMatching> groupMatchings = Maps.newConcurrentMap();
+    private final AtomicInteger persistentFanout = new AtomicInteger();
+    private int maxPersistentFanout;
+    private int maxGroupFanout;
+
+    public MatchedRoutes(String tenantId,
+                         String topic,
+                         IEventCollector eventCollector,
+                         int maxPersistentFanout,
+                         int maxGroupFanout) {
+        this.tenantId = tenantId;
+        this.topic = topic;
+        this.eventCollector = eventCollector;
+        this.maxPersistentFanout = maxPersistentFanout;
+        this.maxGroupFanout = maxGroupFanout;
+    }
+
+
+    @Override
+    public int maxPersistentFanout() {
+        return maxPersistentFanout;
+    }
+
+    @Override
+    public int maxGroupFanout() {
+        return maxGroupFanout;
+    }
+
+    @Override
+    public int persistentFanout() {
+        return persistentFanout.get();
+    }
+
+    @Override
+    public int groupFanout() {
+        return groupMatchings.size();
+    }
+
+    @Override
+    public Set<Matching> routes() {
+        return allMatchings;
+    }
+
+    @Override
+    public AddResult addNormalMatching(NormalMatching matching) {
+        if (allMatchings.add(matching)) {
+            if (matching.subBrokerId() == 1) {
+                if (persistentFanout.get() < maxPersistentFanout) {
+                    persistentFanout.incrementAndGet();
+                    return AddResult.Added;
+                } else {
+                    allMatchings.remove(matching);
+                    eventCollector.report(getLocal(PersistentFanoutThrottled.class)
+                        .tenantId(tenantId)
+                        .topic(topic)
+                        .mqttTopicFilter(matching.mqttTopicFilter())
+                        .maxCount(maxPersistentFanout)
+                    );
+                    return AddResult.ExceedFanoutLimit;
+                }
+            } else {
+                return AddResult.Added;
+            }
+        }
+        return AddResult.Exists;
+    }
+
+    @Override
+    public void removeNormalMatching(NormalMatching matching) {
+        if (allMatchings.remove(matching)) {
+            if (matching.subBrokerId() == 1) {
+                persistentFanout.decrementAndGet();
+            }
+        }
+    }
+
+    @Override
+    public AddResult putGroupMatching(GroupMatching matching) {
+        GroupMatching prev = groupMatchings.put(matching.mqttTopicFilter(), matching);
+        if (prev == null) {
+            if (groupMatchings.size() <= maxGroupFanout) {
+                allMatchings.add(matching);
+                return AddResult.Added;
+            } else {
+                groupMatchings.remove(matching.mqttTopicFilter());
+                eventCollector.report(getLocal(GroupFanoutThrottled.class)
+                    .tenantId(tenantId)
+                    .topic(topic)
+                    .mqttTopicFilter(matching.mqttTopicFilter())
+                    .maxCount(maxGroupFanout)
+                );
+                return AddResult.ExceedFanoutLimit;
+            }
+        } else {
+            allMatchings.remove(prev);
+            allMatchings.add(matching);
+            return AddResult.Exists;
+        }
+    }
+
+    @Override
+    public void removeGroupMatching(GroupMatching matching) {
+        assert matching.receivers().isEmpty();
+        removeGroupMatching(matching.mqttTopicFilter());
+    }
+
+    private void removeGroupMatching(String mqttTopicFilter) {
+        GroupMatching existing = groupMatchings.remove(mqttTopicFilter);
+        if (existing != null) {
+            allMatchings.remove(existing);
+        }
+    }
+
+    @Override
+    public AdjustResult adjust(int newMaxPersistentFanout, int newMaxGroupFanout) {
+        // current limit increases and cachedRoutes reached the previous limit, need refresh
+        if (maxPersistentFanout < newMaxPersistentFanout && persistentFanout.get() == maxPersistentFanout) {
+            return AdjustResult.ReloadNeeded;
+        }
+        if (maxGroupFanout < newMaxGroupFanout && groupMatchings.size() == maxGroupFanout) {
+            return AdjustResult.ReloadNeeded;
+        }
+        // current limit decreases and cachedRoutes exceeded the current limit, need refresh
+        boolean clamped = false;
+        if (maxPersistentFanout > newMaxPersistentFanout && persistentFanout.get() > newMaxPersistentFanout) {
+            // clamp persistent fanout
+            int toRemove = persistentFanout.get() - newMaxPersistentFanout;
+            List<NormalMatching> toRemoved = new ArrayList<>(toRemove);
+            for (Matching matching : allMatchings) {
+                if (toRemove == 0) {
+                    break;
+                }
+                if (matching.type() == Matching.Type.Normal && ((NormalMatching) matching).subBrokerId() == 1) {
+                    toRemoved.add((NormalMatching) matching);
+                    toRemove--;
+                }
+            }
+            toRemoved.forEach(this::removeNormalMatching);
+            clamped = true;
+        }
+        if (maxGroupFanout > newMaxGroupFanout && groupMatchings.size() > newMaxGroupFanout) {
+            // clamp persistent fanout
+            int toRemove = groupMatchings.size() - newMaxGroupFanout;
+            List<String> toRemoved = new ArrayList<>(toRemove);
+            for (String mqttTopicFilter : groupMatchings.keySet()) {
+                if (toRemove == 0) {
+                    break;
+                }
+                toRemoved.add(mqttTopicFilter);
+                toRemove--;
+            }
+            toRemoved.forEach(this::removeGroupMatching);
+            clamped = true;
+        }
+        maxPersistentFanout = newMaxPersistentFanout;
+        maxGroupFanout = newMaxGroupFanout;
+        if (clamped) {
+            return AdjustResult.Clamped;
+        }
+        return AdjustResult.Adjusted;
+    }
+}

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/RouteCacheKey.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/RouteCacheKey.java
@@ -17,40 +17,21 @@
  * under the License.
  */
 
-package org.apache.bifromq.dist.worker.schema;
+package org.apache.bifromq.dist.worker.cache;
 
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import org.apache.bifromq.type.RouteMatcher;
+import org.apache.bifromq.basekv.proto.Boundary;
 
-/**
- * The abstract class of matching route.
- */
 @EqualsAndHashCode(cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY)
-@ToString
-public abstract class Matching {
+public final class RouteCacheKey {
+    public final String topic;
+    public final Boundary matchRecordBoundary;
     @EqualsAndHashCode.Exclude
-    public final RouteMatcher matcher;
-    private final String tenantId;
-    private final String mqttTopicFilter;
+    public final AtomicReference<IMatchedRoutes> cachedMatchedRoutes = new AtomicReference<>();
 
-    protected Matching(String tenantId, RouteMatcher matcher) {
-        this.tenantId = tenantId;
-        this.matcher = matcher;
-        this.mqttTopicFilter = matcher.getMqttTopicFilter();
-    }
-
-    public abstract Type type();
-
-    public final String tenantId() {
-        return tenantId;
-    }
-
-    public final String mqttTopicFilter() {
-        return mqttTopicFilter;
-    }
-
-    public enum Type {
-        Normal, Group
+    public RouteCacheKey(String topic, Boundary matchRecordBoundary) {
+        this.topic = topic;
+        this.matchRecordBoundary = matchRecordBoundary;
     }
 }

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/SubscriptionCache.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/SubscriptionCache.java
@@ -35,7 +35,6 @@ import com.google.protobuf.ByteString;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -46,12 +45,12 @@ import org.apache.bifromq.basekv.proto.Boundary;
 import org.apache.bifromq.basekv.proto.KVRangeId;
 import org.apache.bifromq.basekv.store.api.IKVCloseableReader;
 import org.apache.bifromq.basekv.utils.KVRangeIdUtil;
+import org.apache.bifromq.dist.worker.cache.task.RefreshEntriesTask;
 import org.apache.bifromq.dist.worker.schema.Matching;
 import org.apache.bifromq.plugin.eventcollector.IEventCollector;
 import org.apache.bifromq.plugin.settingprovider.ISettingProvider;
 import org.apache.bifromq.sysprops.props.DistCachedRoutesFanoutCheckIntervalSeconds;
 import org.apache.bifromq.sysprops.props.DistTopicMatchExpirySeconds;
-import org.apache.bifromq.type.RouteMatcher;
 
 /**
  * Cache for subscription matching.
@@ -125,7 +124,7 @@ public class SubscriptionCache implements ISubscriptionCache {
     }
 
     @Override
-    public void refresh(Map<String, NavigableSet<RouteMatcher>> topicFiltersByTenant) {
+    public void refresh(Map<String, RefreshEntriesTask> topicFiltersByTenant) {
         topicFiltersByTenant.forEach((tenantId, topicFilters) -> {
             ITenantRouteCache cache = tenantCache.getIfPresent(noRefreshExpiry(tenantId));
             if (cache != null) {

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/AddRoutesTask.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/AddRoutesTask.java
@@ -17,40 +17,26 @@
  * under the License.
  */
 
-package org.apache.bifromq.dist.worker.schema;
+package org.apache.bifromq.dist.worker.cache.task;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import java.util.NavigableMap;
+import java.util.Set;
+import org.apache.bifromq.dist.worker.schema.Matching;
 import org.apache.bifromq.type.RouteMatcher;
 
-/**
- * The abstract class of matching route.
- */
-@EqualsAndHashCode(cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY)
-@ToString
-public abstract class Matching {
-    @EqualsAndHashCode.Exclude
-    public final RouteMatcher matcher;
-    private final String tenantId;
-    private final String mqttTopicFilter;
+public class AddRoutesTask extends RefreshEntriesTask {
 
-    protected Matching(String tenantId, RouteMatcher matcher) {
-        this.tenantId = tenantId;
-        this.matcher = matcher;
-        this.mqttTopicFilter = matcher.getMqttTopicFilter();
+    private AddRoutesTask(
+        NavigableMap<RouteMatcher, Set<Matching>> removed) {
+        super(removed);
     }
 
-    public abstract Type type();
-
-    public final String tenantId() {
-        return tenantId;
+    public static AddRoutesTask of(NavigableMap<RouteMatcher, Set<Matching>> added) {
+        return new AddRoutesTask(added);
     }
 
-    public final String mqttTopicFilter() {
-        return mqttTopicFilter;
-    }
-
-    public enum Type {
-        Normal, Group
+    @Override
+    public CacheTaskType type() {
+        return CacheTaskType.AddRoutes;
     }
 }

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/CacheTaskType.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/CacheTaskType.java
@@ -17,24 +17,8 @@
  * under the License.
  */
 
-package org.apache.bifromq.dist.worker.cache;
+package org.apache.bifromq.dist.worker.cache.task;
 
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import org.apache.bifromq.basekv.proto.Boundary;
-import org.apache.bifromq.dist.worker.cache.task.RefreshEntriesTask;
-import org.apache.bifromq.dist.worker.schema.Matching;
-
-/**
- * Cache for matched routes for given tenant.
- */
-public interface ITenantRouteCache {
-    boolean isCached(List<String> filterLevels);
-
-    void refresh(RefreshEntriesTask task);
-
-    CompletableFuture<Set<Matching>> getMatch(String topic, Boundary currentTenantRange);
-
-    void destroy();
+public enum CacheTaskType {
+    Load, Reload, AddRoutes, RemoveRoutes
 }

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/LoadEntryTask.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/LoadEntryTask.java
@@ -17,24 +17,28 @@
  * under the License.
  */
 
-package org.apache.bifromq.dist.worker.cache;
+package org.apache.bifromq.dist.worker.cache.task;
 
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import org.apache.bifromq.basekv.proto.Boundary;
-import org.apache.bifromq.dist.worker.cache.task.RefreshEntriesTask;
-import org.apache.bifromq.dist.worker.schema.Matching;
+import org.apache.bifromq.dist.worker.cache.IMatchedRoutes;
+import org.apache.bifromq.dist.worker.cache.RouteCacheKey;
 
-/**
- * Cache for matched routes for given tenant.
- */
-public interface ITenantRouteCache {
-    boolean isCached(List<String> filterLevels);
+public class LoadEntryTask extends TenantRouteCacheTask {
+    public final String topic;
+    public final RouteCacheKey cacheKey;
+    public final CompletableFuture<IMatchedRoutes> future = new CompletableFuture<>();
 
-    void refresh(RefreshEntriesTask task);
+    private LoadEntryTask(String topic, RouteCacheKey cacheKey) {
+        this.topic = topic;
+        this.cacheKey = cacheKey;
+    }
 
-    CompletableFuture<Set<Matching>> getMatch(String topic, Boundary currentTenantRange);
+    public static LoadEntryTask of(String topic, RouteCacheKey cacheKey) {
+        return new LoadEntryTask(topic, cacheKey);
+    }
 
-    void destroy();
+    @Override
+    public final CacheTaskType type() {
+        return CacheTaskType.Load;
+    }
 }

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/RefreshEntriesTask.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/RefreshEntriesTask.java
@@ -17,40 +17,17 @@
  * under the License.
  */
 
-package org.apache.bifromq.dist.worker.schema;
+package org.apache.bifromq.dist.worker.cache.task;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import java.util.NavigableMap;
+import java.util.Set;
+import org.apache.bifromq.dist.worker.schema.Matching;
 import org.apache.bifromq.type.RouteMatcher;
 
-/**
- * The abstract class of matching route.
- */
-@EqualsAndHashCode(cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY)
-@ToString
-public abstract class Matching {
-    @EqualsAndHashCode.Exclude
-    public final RouteMatcher matcher;
-    private final String tenantId;
-    private final String mqttTopicFilter;
+public abstract class RefreshEntriesTask extends TenantRouteCacheTask {
+    public final NavigableMap<RouteMatcher, Set<Matching>> routes;
 
-    protected Matching(String tenantId, RouteMatcher matcher) {
-        this.tenantId = tenantId;
-        this.matcher = matcher;
-        this.mqttTopicFilter = matcher.getMqttTopicFilter();
-    }
-
-    public abstract Type type();
-
-    public final String tenantId() {
-        return tenantId;
-    }
-
-    public final String mqttTopicFilter() {
-        return mqttTopicFilter;
-    }
-
-    public enum Type {
-        Normal, Group
+    protected RefreshEntriesTask(NavigableMap<RouteMatcher, Set<Matching>> removed) {
+        this.routes = removed;
     }
 }

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/ReloadEntryTask.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/ReloadEntryTask.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bifromq.dist.worker.cache.task;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.bifromq.dist.worker.cache.IMatchedRoutes;
+import org.apache.bifromq.dist.worker.cache.RouteCacheKey;
+
+public class ReloadEntryTask extends TenantRouteCacheTask {
+    public final String topic;
+    public final RouteCacheKey cacheKey;
+    public final int maxPersistentFanouts;
+    public final int maxGroupFanouts;
+    public final CompletableFuture<IMatchedRoutes> future = new CompletableFuture<>();
+
+
+    private ReloadEntryTask(String topic, RouteCacheKey cacheKey, int maxPersistentFanouts, int maxGroupFanouts) {
+        this.topic = topic;
+        this.cacheKey = cacheKey;
+        this.maxPersistentFanouts = maxPersistentFanouts;
+        this.maxGroupFanouts = maxGroupFanouts;
+    }
+
+    public static ReloadEntryTask of(String topic,
+                                     RouteCacheKey cacheKey,
+                                     int maxPersistentFanouts,
+                                     int maxGroupFanouts) {
+        return new ReloadEntryTask(topic, cacheKey, maxPersistentFanouts, maxGroupFanouts);
+    }
+
+    @Override
+    public CacheTaskType type() {
+        return CacheTaskType.Reload;
+    }
+}

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/RemoveRoutesTask.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/RemoveRoutesTask.java
@@ -17,40 +17,26 @@
  * under the License.
  */
 
-package org.apache.bifromq.dist.worker.schema;
+package org.apache.bifromq.dist.worker.cache.task;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import java.util.NavigableMap;
+import java.util.Set;
+import org.apache.bifromq.dist.worker.schema.Matching;
 import org.apache.bifromq.type.RouteMatcher;
 
-/**
- * The abstract class of matching route.
- */
-@EqualsAndHashCode(cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY)
-@ToString
-public abstract class Matching {
-    @EqualsAndHashCode.Exclude
-    public final RouteMatcher matcher;
-    private final String tenantId;
-    private final String mqttTopicFilter;
+public class RemoveRoutesTask extends RefreshEntriesTask {
 
-    protected Matching(String tenantId, RouteMatcher matcher) {
-        this.tenantId = tenantId;
-        this.matcher = matcher;
-        this.mqttTopicFilter = matcher.getMqttTopicFilter();
+    private RemoveRoutesTask(
+        NavigableMap<RouteMatcher, Set<Matching>> removed) {
+        super(removed);
     }
 
-    public abstract Type type();
-
-    public final String tenantId() {
-        return tenantId;
+    public static RemoveRoutesTask of(NavigableMap<RouteMatcher, Set<Matching>> added) {
+        return new RemoveRoutesTask(added);
     }
 
-    public final String mqttTopicFilter() {
-        return mqttTopicFilter;
-    }
-
-    public enum Type {
-        Normal, Group
+    @Override
+    public CacheTaskType type() {
+        return CacheTaskType.RemoveRoutes;
     }
 }

--- a/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/TenantRouteCacheTask.java
+++ b/bifromq-dist/bifromq-dist-worker/src/main/java/org/apache/bifromq/dist/worker/cache/task/TenantRouteCacheTask.java
@@ -17,24 +17,8 @@
  * under the License.
  */
 
-package org.apache.bifromq.dist.worker.cache;
+package org.apache.bifromq.dist.worker.cache.task;
 
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import org.apache.bifromq.basekv.proto.Boundary;
-import org.apache.bifromq.dist.worker.cache.task.RefreshEntriesTask;
-import org.apache.bifromq.dist.worker.schema.Matching;
-
-/**
- * Cache for matched routes for given tenant.
- */
-public interface ITenantRouteCache {
-    boolean isCached(List<String> filterLevels);
-
-    void refresh(RefreshEntriesTask task);
-
-    CompletableFuture<Set<Matching>> getMatch(String topic, Boundary currentTenantRange);
-
-    void destroy();
+public abstract class TenantRouteCacheTask {
+    public abstract CacheTaskType type();
 }

--- a/bifromq-dist/bifromq-dist-worker/src/test/java/org/apache/bifromq/dist/worker/DistWorkerCoProcTest.java
+++ b/bifromq-dist/bifromq-dist-worker/src/test/java/org/apache/bifromq/dist/worker/DistWorkerCoProcTest.java
@@ -14,7 +14,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License.    
+ * under the License.
  */
 
 package org.apache.bifromq.dist.worker;
@@ -36,6 +36,14 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import lombok.SneakyThrows;
 import org.apache.bifromq.basekv.proto.Boundary;
 import org.apache.bifromq.basekv.proto.KVRangeId;
 import org.apache.bifromq.basekv.store.api.IKVCloseableReader;
@@ -67,14 +75,6 @@ import org.apache.bifromq.plugin.subbroker.CheckRequest;
 import org.apache.bifromq.type.TopicMessagePack;
 import org.apache.bifromq.util.BSUtil;
 import org.apache.bifromq.util.TopicUtil;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
-import lombok.SneakyThrows;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -165,7 +165,8 @@ public class DistWorkerCoProcTest {
 
         // Verify that matches are removed from the cache
         verify(routeCache, times(1)).refresh(
-            argThat(m -> m.containsKey("tenant1") && m.get("tenant1").contains(TopicUtil.from("topicFilter1"))));
+            argThat(m -> m.containsKey("tenant1") && m.get("tenant1").routes.keySet()
+                .contains(TopicUtil.from("topicFilter1"))));
 
         // Verify that tenant state is updated
         verify(tenantsState, times(1)).decNormalRoutes(eq("tenant1"), eq(1));
@@ -240,7 +241,8 @@ public class DistWorkerCoProcTest {
 
         verify(writer, times(1)).delete(any(ByteString.class));
         verify(routeCache, times(1)).refresh(
-            argThat(m -> m.containsKey("tenant1") && m.get("tenant1").contains(TopicUtil.from("topicFilter1"))));
+            argThat(m -> m.containsKey("tenant1") && m.get("tenant1").routes.keySet()
+                .contains(TopicUtil.from("topicFilter1"))));
         verify(tenantsState, times(1)).decNormalRoutes(eq("tenant1"), eq(1));
 
         try {
@@ -371,7 +373,8 @@ public class DistWorkerCoProcTest {
 
         verify(writer, times(1)).delete(any(ByteString.class));
         verify(routeCache, times(1)).refresh(argThat(m -> m.containsKey("tenantA")
-            && m.get("tenantA").contains(TopicUtil.from("topicA"))));
+            && m.get("tenantA").routes.keySet()
+            .contains(TopicUtil.from("topicA"))));
         verify(tenantsState, times(1)).decNormalRoutes(eq("tenantA"), eq(1));
         verify(reader, times(1)).refresh();
     }
@@ -411,7 +414,7 @@ public class DistWorkerCoProcTest {
 
         verify(writer, times(1)).delete(any(ByteString.class));
         verify(routeCache, times(1)).refresh(argThat(m -> m.containsKey("tenantB")
-            && m.get("tenantB").contains(TopicUtil.from("topicB"))));
+            && m.get("tenantB").routes.keySet().contains(TopicUtil.from("topicB"))));
         verify(tenantsState, times(1)).decNormalRoutes(eq("tenantB"), eq(1));
         verify(reader, times(1)).refresh();
     }

--- a/bifromq-dist/bifromq-dist-worker/src/test/java/org/apache/bifromq/dist/worker/cache/MatchedRoutesTest.java
+++ b/bifromq-dist/bifromq-dist-worker/src/test/java/org/apache/bifromq/dist/worker/cache/MatchedRoutesTest.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bifromq.dist.worker.cache;
+
+import static org.apache.bifromq.dist.worker.schema.Matchings.normalMatching;
+import static org.apache.bifromq.dist.worker.schema.Matchings.receiverUrl;
+import static org.apache.bifromq.dist.worker.schema.Matchings.unorderedGroupMatching;
+import static org.apache.bifromq.plugin.eventcollector.EventType.GROUP_FANOUT_THROTTLED;
+import static org.apache.bifromq.plugin.eventcollector.EventType.PERSISTENT_FANOUT_THROTTLED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Map;
+import org.apache.bifromq.dist.worker.schema.GroupMatching;
+import org.apache.bifromq.dist.worker.schema.Matching;
+import org.apache.bifromq.dist.worker.schema.NormalMatching;
+import org.apache.bifromq.plugin.eventcollector.IEventCollector;
+import org.apache.bifromq.plugin.eventcollector.distservice.GroupFanoutThrottled;
+import org.apache.bifromq.plugin.eventcollector.distservice.PersistentFanoutThrottled;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MatchedRoutesTest {
+    private static final String TENANT_ID = "tenantA";
+    private static final String TOPIC = "sensor/temperature";
+    private static final String GROUP_FILTER = "sensor/+";
+
+    private IEventCollector eventCollector;
+
+    @BeforeMethod
+    public void setUp() {
+        eventCollector = mock(IEventCollector.class);
+    }
+
+    @Test
+    public void addPersistentNormalMatchingWithinLimit() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 2);
+        NormalMatching persistent = normalMatching(TENANT_ID, TOPIC, 1, "receiverA", "delivererA", 1);
+
+        IMatchedRoutes.AddResult result = routes.addNormalMatching(persistent);
+
+        assertEquals(result, IMatchedRoutes.AddResult.Added);
+        assertEquals(routes.persistentFanout(), 1);
+        assertEquals(routes.maxPersistentFanout(), 2);
+        assertTrue(routes.routes().contains(persistent));
+        verify(eventCollector, never()).report(any());
+    }
+
+    @Test
+    public void addPersistentNormalMatchingExceedLimit() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 1, 2);
+        NormalMatching first = normalMatching(TENANT_ID, TOPIC, 1, "receiverA", "delivererA", 1);
+        NormalMatching second = normalMatching(TENANT_ID, TOPIC, 1, "receiverB", "delivererB", 2);
+
+        assertEquals(routes.addNormalMatching(first), IMatchedRoutes.AddResult.Added);
+        IMatchedRoutes.AddResult result = routes.addNormalMatching(second);
+
+        assertEquals(result, IMatchedRoutes.AddResult.ExceedFanoutLimit);
+        assertEquals(routes.persistentFanout(), 1);
+        assertFalse(routes.routes().contains(second));
+        verify(eventCollector, times(1)).report(argThat(e -> {
+            if (e.type() != PERSISTENT_FANOUT_THROTTLED) {
+                return false;
+            }
+            PersistentFanoutThrottled event = (PersistentFanoutThrottled) e;
+            return event.tenantId().equals(TENANT_ID)
+                && event.topic().equals(TOPIC)
+                && event.mqttTopicFilter().equals(second.mqttTopicFilter())
+                && event.maxCount() == 1;
+        }));
+    }
+
+    @Test
+    public void addNonPersistentNormalMatchingDoesNotAffectPersistentFanout() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 1, 2);
+        NormalMatching nonPersistent = normalMatching(TENANT_ID, TOPIC, 2, "receiverC", "delivererC", 1);
+
+        IMatchedRoutes.AddResult result = routes.addNormalMatching(nonPersistent);
+
+        assertEquals(result, IMatchedRoutes.AddResult.Added);
+        assertEquals(routes.persistentFanout(), 0);
+        assertTrue(routes.routes().contains(nonPersistent));
+    }
+
+    @Test
+    public void addDuplicateNormalMatchingReturnsExists() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 2);
+        NormalMatching matching = normalMatching(TENANT_ID, TOPIC, 1, "receiverA", "delivererA", 1);
+
+        assertEquals(routes.addNormalMatching(matching), IMatchedRoutes.AddResult.Added);
+        IMatchedRoutes.AddResult second = routes.addNormalMatching(matching);
+
+        assertEquals(second, IMatchedRoutes.AddResult.Exists);
+        assertEquals(routes.persistentFanout(), 1);
+        assertEquals(routes.routes().stream()
+            .filter(m -> m.type() == Matching.Type.Normal && ((NormalMatching) m).subBrokerId() == 1)
+            .count(), 1);
+    }
+
+    @Test
+    public void removePersistentNormalMatching() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 2);
+        NormalMatching persistent = normalMatching(TENANT_ID, TOPIC, 1, "receiverA", "delivererA", 1);
+        routes.addNormalMatching(persistent);
+
+        routes.removeNormalMatching(persistent);
+
+        assertEquals(routes.persistentFanout(), 0);
+        assertFalse(routes.routes().contains(persistent));
+
+        // second removal should be a no-op
+        routes.removeNormalMatching(persistent);
+        assertEquals(routes.persistentFanout(), 0);
+    }
+
+    @Test
+    public void removeNonPersistentNormalMatching() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 2);
+        NormalMatching nonPersistent = normalMatching(TENANT_ID, TOPIC, 2, "receiverB", "delivererB", 1);
+        routes.addNormalMatching(nonPersistent);
+
+        routes.removeNormalMatching(nonPersistent);
+
+        assertEquals(routes.persistentFanout(), 0);
+        assertFalse(routes.routes().contains(nonPersistent));
+    }
+
+    @Test
+    public void putGroupMatchingWithinLimit() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 2);
+        GroupMatching group = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupA",
+            Map.of(receiverUrl(1, "receiverA", "delivererA"), 1L));
+
+        IMatchedRoutes.AddResult result = routes.putGroupMatching(group);
+
+        assertEquals(result, IMatchedRoutes.AddResult.Added);
+        assertEquals(routes.groupFanout(), 1);
+        assertTrue(routes.routes().contains(group));
+        verify(eventCollector, never()).report(any());
+    }
+
+    @Test
+    public void putGroupMatchingExceedLimit() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 1);
+        GroupMatching first = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupA",
+            Map.of(receiverUrl(1, "receiverA", "delivererA"), 1L));
+        GroupMatching second = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupB",
+            Map.of(receiverUrl(1, "receiverB", "delivererB"), 1L));
+
+        assertEquals(routes.putGroupMatching(first), IMatchedRoutes.AddResult.Added);
+        IMatchedRoutes.AddResult result = routes.putGroupMatching(second);
+
+        assertEquals(result, IMatchedRoutes.AddResult.ExceedFanoutLimit);
+        assertEquals(routes.groupFanout(), 1);
+        assertFalse(routes.routes().contains(second));
+        verify(eventCollector, times(1)).report(argThat(e -> {
+            if (e.type() != GROUP_FANOUT_THROTTLED) {
+                return false;
+            }
+            GroupFanoutThrottled event = (GroupFanoutThrottled) e;
+            return event.tenantId().equals(TENANT_ID)
+                && event.topic().equals(TOPIC)
+                && event.mqttTopicFilter().equals(second.mqttTopicFilter())
+                && event.maxCount() == 1;
+        }));
+    }
+
+    @Test
+    public void putGroupMatchingReplacesExistingGroup() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 3);
+        GroupMatching original = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupA",
+            Map.of(receiverUrl(1, "receiverA", "delivererA"), 1L));
+        GroupMatching replacement = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupA",
+            Map.of(receiverUrl(1, "receiverB", "delivererB"), 2L));
+
+        assertEquals(routes.putGroupMatching(original), IMatchedRoutes.AddResult.Added);
+        IMatchedRoutes.AddResult result = routes.putGroupMatching(replacement);
+
+        assertEquals(result, IMatchedRoutes.AddResult.Exists);
+        assertEquals(routes.groupFanout(), 1);
+        assertTrue(routes.routes().contains(replacement));
+        assertFalse(routes.routes().contains(original));
+    }
+
+    @Test
+    public void removeGroupMatching() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 2);
+        GroupMatching group = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupA", Map.of());
+        routes.putGroupMatching(group);
+
+        routes.removeGroupMatching(group);
+
+        assertEquals(routes.groupFanout(), 0);
+        assertFalse(routes.routes().contains(group));
+
+        routes.removeGroupMatching(group);
+        assertEquals(routes.groupFanout(), 0);
+    }
+
+    @Test
+    public void adjustReturnsReloadNeededWhenPersistentLimitIncreases() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 1, 2);
+        routes.addNormalMatching(normalMatching(TENANT_ID, TOPIC, 1, "receiverA", "delivererA", 1));
+
+        IMatchedRoutes.AdjustResult result = routes.adjust(2, routes.maxGroupFanout());
+
+        assertEquals(result, IMatchedRoutes.AdjustResult.ReloadNeeded);
+    }
+
+    @Test
+    public void adjustReturnsReloadNeededWhenGroupLimitIncreases() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 1);
+        routes.putGroupMatching(unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupA",
+            Map.of(receiverUrl(1, "receiverA", "delivererA"), 1L)));
+
+        IMatchedRoutes.AdjustResult result = routes.adjust(routes.maxPersistentFanout(), 2);
+
+        assertEquals(result, IMatchedRoutes.AdjustResult.ReloadNeeded);
+    }
+
+    @Test
+    public void adjustClampsPersistentFanoutWhenLimitDecreases() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 3, 2);
+        NormalMatching first = normalMatching(TENANT_ID, TOPIC, 1, "receiverA", "delivererA", 1);
+        NormalMatching second = normalMatching(TENANT_ID, TOPIC, 1, "receiverB", "delivererB", 2);
+        NormalMatching third = normalMatching(TENANT_ID, TOPIC, 1, "receiverC", "delivererC", 3);
+        routes.addNormalMatching(first);
+        routes.addNormalMatching(second);
+        routes.addNormalMatching(third);
+
+        IMatchedRoutes.AdjustResult result = routes.adjust(1, routes.maxGroupFanout());
+
+        assertEquals(result, IMatchedRoutes.AdjustResult.Clamped);
+        assertEquals(routes.persistentFanout(), 1);
+        long persistentCount = routes.routes().stream()
+            .filter(m -> m.type() == Matching.Type.Normal && ((NormalMatching) m).subBrokerId() == 1)
+            .count();
+        assertEquals(persistentCount, 1);
+
+        IMatchedRoutes.AdjustResult secondResult = routes.adjust(1, routes.maxGroupFanout());
+        assertEquals(secondResult, IMatchedRoutes.AdjustResult.Adjusted);
+    }
+
+    @Test
+    public void adjustClampsGroupFanoutWhenLimitDecreases() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 3);
+        GroupMatching g1 = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupA",
+            Map.of(receiverUrl(1, "receiverA", "delivererA"), 1L));
+        GroupMatching g2 = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupB",
+            Map.of(receiverUrl(1, "receiverB", "delivererB"), 1L));
+        GroupMatching g3 = unorderedGroupMatching(TENANT_ID, GROUP_FILTER, "groupC",
+            Map.of(receiverUrl(1, "receiverC", "delivererC"), 1L));
+        routes.putGroupMatching(g1);
+        routes.putGroupMatching(g2);
+        routes.putGroupMatching(g3);
+
+        IMatchedRoutes.AdjustResult result = routes.adjust(routes.maxPersistentFanout(), 1);
+
+        assertEquals(result, IMatchedRoutes.AdjustResult.Clamped);
+        assertEquals(routes.groupFanout(), 1);
+        long groupCount = routes.routes().stream().filter(m -> m.type() == Matching.Type.Group).count();
+        assertEquals(groupCount, 1);
+
+        IMatchedRoutes.AdjustResult secondResult = routes.adjust(routes.maxPersistentFanout(), 1);
+        assertEquals(secondResult, IMatchedRoutes.AdjustResult.Adjusted);
+    }
+
+    @Test
+    public void adjustUpdatesLimitsWhenWithinBounds() {
+        MatchedRoutes routes = new MatchedRoutes(TENANT_ID, TOPIC, eventCollector, 2, 2);
+
+        IMatchedRoutes.AdjustResult result = routes.adjust(4, 3);
+
+        assertEquals(result, IMatchedRoutes.AdjustResult.Adjusted);
+        assertEquals(routes.maxPersistentFanout(), 4);
+        assertEquals(routes.maxGroupFanout(), 3);
+    }
+}

--- a/bifromq-dist/bifromq-dist-worker/src/test/java/org/apache/bifromq/dist/worker/cache/TenantRouteMatcherTest.java
+++ b/bifromq-dist/bifromq-dist-worker/src/test/java/org/apache/bifromq/dist/worker/cache/TenantRouteMatcherTest.java
@@ -1,0 +1,507 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bifromq.dist.worker.cache;
+
+import static org.apache.bifromq.basekv.utils.BoundaryUtil.FULL_BOUNDARY;
+import static org.apache.bifromq.basekv.utils.BoundaryUtil.toBoundary;
+import static org.apache.bifromq.basekv.utils.BoundaryUtil.upperBound;
+import static org.apache.bifromq.dist.worker.schema.KVSchemaUtil.toGroupRouteKey;
+import static org.apache.bifromq.dist.worker.schema.KVSchemaUtil.toNormalRouteKey;
+import static org.apache.bifromq.dist.worker.schema.Matchings.normalMatching;
+import static org.apache.bifromq.dist.worker.schema.Matchings.receiverUrl;
+import static org.apache.bifromq.dist.worker.schema.Matchings.unorderedGroupMatching;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.google.protobuf.ByteString;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
+import org.apache.bifromq.basekv.proto.Boundary;
+import org.apache.bifromq.basekv.store.api.IKVIterator;
+import org.apache.bifromq.basekv.store.api.IKVReader;
+import org.apache.bifromq.basekv.utils.BoundaryUtil;
+import org.apache.bifromq.dist.rpc.proto.RouteGroup;
+import org.apache.bifromq.dist.worker.schema.GroupMatching;
+import org.apache.bifromq.dist.worker.schema.Matching;
+import org.apache.bifromq.dist.worker.schema.NormalMatching;
+import org.apache.bifromq.plugin.eventcollector.Event;
+import org.apache.bifromq.plugin.eventcollector.IEventCollector;
+import org.apache.bifromq.plugin.eventcollector.distservice.GroupFanoutThrottled;
+import org.apache.bifromq.plugin.eventcollector.distservice.PersistentFanoutThrottled;
+import org.apache.bifromq.util.BSUtil;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TenantRouteMatcherTest {
+    private static final String TENANT_ID = "tenantA";
+    private static final String OTHER_TENANT = "tenantB";
+
+    private SimpleMeterRegistry meterRegistry;
+    private RecordingEventCollector eventCollector;
+    private Timer matchTimer;
+
+    private static NavigableMap<ByteString, ByteString> newTreeMap() {
+        return new TreeMap<>(ByteString.unsignedLexicographicalComparator());
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        eventCollector = new RecordingEventCollector();
+        matchTimer = meterRegistry.timer("tenantRouteMatch");
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        meterRegistry.close();
+    }
+
+    @Test
+    public void matchAllReturnsEmptyWhenNoTenantDataPresent() {
+        NavigableMap<ByteString, ByteString> kvData = newTreeMap();
+        NormalMatching otherTenantRoute = normalMatching(OTHER_TENANT, "sensors/+/temp", 1, "receiverX", "delivererX",
+            1);
+        kvData.put(toNormalRouteKey(OTHER_TENANT, otherTenantRoute.matcher, otherTenantRoute.receiverUrl()),
+            BSUtil.toByteString(otherTenantRoute.incarnation()));
+
+        Set<String> topics = Set.of("sensors/device1/temp", "sensors/device1/humidity");
+        TenantRouteMatcher matcher =
+            new TenantRouteMatcher(TENANT_ID, () -> new TreeMapKVReader(kvData), eventCollector, matchTimer);
+
+        Map<String, IMatchedRoutes> matchedRoutes = matcher.matchAll(topics, 10, 10);
+
+        assertEquals(matchedRoutes.keySet(), topics);
+        matchedRoutes.values().forEach(routes -> {
+            assertTrue(routes.routes().isEmpty());
+            assertEquals(routes.persistentFanout(), 0);
+            assertEquals(routes.groupFanout(), 0);
+        });
+        assertTrue(eventCollector.events().isEmpty());
+    }
+
+    @Test
+    public void matchAllAcrossMultipleTopics() {
+        NavigableMap<ByteString, ByteString> kvData = newTreeMap();
+
+        NormalMatching tempRoute = normalMatching(TENANT_ID, "sensors/+/temp", 1, "receiverA", "delivererA", 1);
+        kvData.put(toNormalRouteKey(TENANT_ID, tempRoute.matcher, tempRoute.receiverUrl()),
+            BSUtil.toByteString(tempRoute.incarnation()));
+
+        NormalMatching humidityRoute =
+            normalMatching(TENANT_ID, "sensors/+/humidity", 1, "receiverB", "delivererB", 2);
+        kvData.put(
+            toNormalRouteKey(TENANT_ID, humidityRoute.matcher, humidityRoute.receiverUrl()),
+            BSUtil.toByteString(humidityRoute.incarnation()));
+
+        TenantRouteMatcher matcher =
+            new TenantRouteMatcher(TENANT_ID, () -> new TreeMapKVReader(kvData), eventCollector, matchTimer);
+
+        Set<String> topics = Set.of(
+            "sensors/device1/temp",
+            "sensors/device1/humidity",
+            "sensors/device2/temp");
+
+        Map<String, IMatchedRoutes> matchedRoutes = matcher.matchAll(topics, 10, 10);
+
+        assertEquals(matchedRoutes.keySet(), topics);
+        assertTrue(matchedRoutes.get("sensors/device1/temp").routes().contains(tempRoute));
+        assertTrue(matchedRoutes.get("sensors/device2/temp").routes().contains(tempRoute));
+        assertTrue(matchedRoutes.get("sensors/device1/humidity").routes().contains(humidityRoute));
+
+        assertEquals(matchedRoutes.get("sensors/device1/temp").persistentFanout(), 1);
+        assertEquals(matchedRoutes.get("sensors/device2/temp").persistentFanout(), 1);
+        assertEquals(matchedRoutes.get("sensors/device1/humidity").persistentFanout(), 1);
+        matchedRoutes.values().forEach(routes -> assertEquals(routes.groupFanout(), 0));
+        assertTrue(eventCollector.events().isEmpty());
+    }
+
+    @Test
+    public void reuseCachedFilterMatchesForRepeatedSubscriptions() {
+        NavigableMap<ByteString, ByteString> kvData = newTreeMap();
+
+        NormalMatching firstRoute = normalMatching(TENANT_ID, "devices/+/status", 1, "receiverA", "delivererA", 1);
+        NormalMatching secondRoute = normalMatching(TENANT_ID, "devices/+/status", 2, "receiverB", "delivererB", 1);
+
+        kvData.put(toNormalRouteKey(TENANT_ID, firstRoute.matcher, firstRoute.receiverUrl()),
+            BSUtil.toByteString(firstRoute.incarnation()));
+        kvData.put(toNormalRouteKey(TENANT_ID, secondRoute.matcher, secondRoute.receiverUrl()),
+            BSUtil.toByteString(secondRoute.incarnation()));
+
+        TenantRouteMatcher matcher =
+            new TenantRouteMatcher(TENANT_ID, () -> new TreeMapKVReader(kvData), eventCollector, matchTimer);
+
+        Set<String> topics = Set.of("devices/a/status", "devices/b/status");
+
+        Map<String, IMatchedRoutes> matchedRoutes = matcher.matchAll(topics, 5, 5);
+
+        topics.forEach(topic -> {
+            IMatchedRoutes routes = matchedRoutes.get(topic);
+            assertTrue(routes.routes().contains(firstRoute));
+            assertTrue(routes.routes().contains(secondRoute));
+            assertEquals(routes.persistentFanout(), 1); // only first route counts as persistent (subBrokerId == 1)
+            assertEquals(routes.groupFanout(), 0);
+        });
+        assertTrue(eventCollector.events().isEmpty());
+    }
+
+    @Test
+    public void matchAllWithSharedSubscription() {
+        NavigableMap<ByteString, ByteString> kvData = newTreeMap();
+
+        GroupMatching groupMatching = unorderedGroupMatching(
+            TENANT_ID,
+            "alerts/+/+/temperature",
+            "groupAlpha",
+            Map.of(receiverUrl(1, "receiverA", "delivererA"), 10L,
+                receiverUrl(2, "receiverB", "delivererB"), 11L));
+
+        kvData.put(toGroupRouteKey(TENANT_ID, groupMatching.matcher),
+            RouteGroup.newBuilder().putAllMembers(groupMatching.receivers()).build().toByteString());
+
+        TenantRouteMatcher matcher =
+            new TenantRouteMatcher(TENANT_ID, () -> new TreeMapKVReader(kvData), eventCollector, matchTimer);
+
+        Set<String> topics = Set.of("alerts/site1/device1/temperature", "alerts/site1/device2/temperature");
+
+        Map<String, IMatchedRoutes> matchedRoutes = matcher.matchAll(topics, 10, 10);
+
+        topics.forEach(topic -> {
+            IMatchedRoutes routes = matchedRoutes.get(topic);
+            assertTrue(routes.routes().contains(groupMatching));
+            assertEquals(routes.persistentFanout(), 0);
+            assertEquals(routes.groupFanout(), 1);
+        });
+        assertTrue(eventCollector.events().isEmpty());
+    }
+
+    @Test
+    public void skipNonMatchingRoutesAndFallbackToSeek() {
+        NavigableMap<ByteString, ByteString> kvData = newTreeMap();
+        for (int i = 0; i < 21; i++) {
+            NormalMatching noise = normalMatching(TENANT_ID, "invalid/" + i, 1, "noise" + i, "deliverer" + i, i);
+            kvData.put(toNormalRouteKey(TENANT_ID, noise.matcher, noise.receiverUrl()),
+                BSUtil.toByteString(noise.incarnation()));
+        }
+
+        NormalMatching valid = normalMatching(TENANT_ID, "metrics/+/cpu", 1, "receiverA", "delivererA", 1);
+        kvData.put(toNormalRouteKey(TENANT_ID, valid.matcher, valid.receiverUrl()),
+            BSUtil.toByteString(valid.incarnation()));
+
+        TreeMapKVReader kvReader = new TreeMapKVReader(kvData);
+        TenantRouteMatcher matcher = new TenantRouteMatcher(TENANT_ID, () -> kvReader, eventCollector, matchTimer);
+
+        Set<String> topics = Set.of("metrics/server1/cpu");
+
+        Map<String, IMatchedRoutes> matchedRoutes = matcher.matchAll(topics, 10, 10);
+
+        IMatchedRoutes result = matchedRoutes.get("metrics/server1/cpu");
+        assertTrue(result.routes().contains(valid));
+        assertEquals(result.persistentFanout(), 1);
+        assertEquals(result.groupFanout(), 0);
+
+        TreeMapKVIterator iterator = kvReader.lastIterator();
+        assertNotNull(iterator);
+        assertTrue(iterator.getSeekCount() >= 2); // initial seek + fallback seek
+        assertTrue(iterator.getNextCount() >= 21); // probed through noise entries
+        assertTrue(eventCollector.events().isEmpty());
+    }
+
+    @Test
+    public void isolateRoutesByTenant() {
+        NavigableMap<ByteString, ByteString> kvData = newTreeMap();
+
+        NormalMatching tenantRoute = normalMatching(TENANT_ID, "devices/+/signal", 1, "receiverA", "delivererA", 1);
+        kvData.put(toNormalRouteKey(TENANT_ID, tenantRoute.matcher, tenantRoute.receiverUrl()),
+            BSUtil.toByteString(tenantRoute.incarnation()));
+
+        NormalMatching otherTenantRoute =
+            normalMatching(OTHER_TENANT, "devices/+/signal", 1, "receiverB", "delivererB", 1);
+        kvData.put(toNormalRouteKey(OTHER_TENANT, otherTenantRoute.matcher, otherTenantRoute.receiverUrl()),
+            BSUtil.toByteString(otherTenantRoute.incarnation()));
+
+        Supplier<IKVReader> readerSupplier = () -> new TreeMapKVReader(kvData);
+
+        TenantRouteMatcher matcherTenant =
+            new TenantRouteMatcher(TENANT_ID, readerSupplier, eventCollector, matchTimer);
+        TenantRouteMatcher matcherOther =
+            new TenantRouteMatcher(OTHER_TENANT, readerSupplier, eventCollector, matchTimer);
+
+        Set<String> topics = Set.of("devices/a/signal");
+
+        Map<String, IMatchedRoutes> tenantMatches = matcherTenant.matchAll(topics, 10, 10);
+        assertTrue(tenantMatches.get("devices/a/signal").routes().contains(tenantRoute));
+        assertFalse(tenantMatches.get("devices/a/signal").routes().contains(otherTenantRoute));
+
+        Map<String, IMatchedRoutes> otherMatches = matcherOther.matchAll(topics, 10, 10);
+        assertTrue(otherMatches.get("devices/a/signal").routes().contains(otherTenantRoute));
+        assertFalse(otherMatches.get("devices/a/signal").routes().contains(tenantRoute));
+
+        assertTrue(eventCollector.events().isEmpty());
+    }
+
+    @Test
+    public void triggerPersistentFanoutThrottling() {
+        NavigableMap<ByteString, ByteString> kvData = newTreeMap();
+
+        NormalMatching first = normalMatching(TENANT_ID, "alarms/+/critical", 1, "receiverA", "delivererA", 1);
+        NormalMatching second = normalMatching(TENANT_ID, "alarms/+/critical", 1, "receiverB", "delivererB", 2);
+
+        kvData.put(toNormalRouteKey(TENANT_ID, first.matcher, first.receiverUrl()),
+            BSUtil.toByteString(first.incarnation()));
+        kvData.put(toNormalRouteKey(TENANT_ID, second.matcher, second.receiverUrl()),
+            BSUtil.toByteString(second.incarnation()));
+
+        TenantRouteMatcher matcher =
+            new TenantRouteMatcher(TENANT_ID, () -> new TreeMapKVReader(kvData), eventCollector, matchTimer);
+
+        Map<String, IMatchedRoutes> matchedRoutes =
+            matcher.matchAll(Set.of("alarms/device1/critical"), 1, 10);
+
+        IMatchedRoutes routes = matchedRoutes.get("alarms/device1/critical");
+        assertEquals(routes.persistentFanout(), 1);
+        assertEquals(routes.groupFanout(), 0);
+        assertEquals(routes.routes().size(), 1);
+
+        List<PersistentFanoutThrottled> events = eventCollector.eventsOfType(PersistentFanoutThrottled.class);
+        assertEquals(events.size(), 1);
+        PersistentFanoutThrottled event = events.get(0);
+        assertEquals(event.tenantId(), TENANT_ID);
+        assertEquals(event.topic(), "alarms/device1/critical");
+        assertEquals(event.mqttTopicFilter(), second.mqttTopicFilter());
+        assertEquals(event.maxCount(), 1);
+    }
+
+    @Test
+    public void triggerGroupFanoutThrottling() {
+        NavigableMap<ByteString, ByteString> kvData = newTreeMap();
+
+        GroupMatching first = unorderedGroupMatching(
+            TENANT_ID,
+            "jobs/+/progress",
+            "groupA",
+            Map.of(receiverUrl(1, "receiverA", "delivererA"), 1L));
+        GroupMatching second = unorderedGroupMatching(
+            TENANT_ID,
+            "jobs/+/progress",
+            "groupB",
+            Map.of(receiverUrl(1, "receiverB", "delivererB"), 1L));
+
+        kvData.put(toGroupRouteKey(TENANT_ID, first.matcher),
+            RouteGroup.newBuilder().putAllMembers(first.receivers()).build().toByteString());
+        kvData.put(toGroupRouteKey(TENANT_ID, second.matcher),
+            RouteGroup.newBuilder().putAllMembers(second.receivers()).build().toByteString());
+
+        TenantRouteMatcher matcher =
+            new TenantRouteMatcher(TENANT_ID, () -> new TreeMapKVReader(kvData), eventCollector, matchTimer);
+
+        Map<String, IMatchedRoutes> matchedRoutes =
+            matcher.matchAll(Set.of("jobs/job1/progress"), 10, 1);
+
+        IMatchedRoutes routes = matchedRoutes.get("jobs/job1/progress");
+        assertEquals(routes.groupFanout(), 1);
+        assertEquals(routes.routes().stream().filter(m -> m.type() == Matching.Type.Group).count(), 1);
+
+        List<GroupFanoutThrottled> events = eventCollector.eventsOfType(GroupFanoutThrottled.class);
+        assertEquals(events.size(), 1);
+        GroupFanoutThrottled event = events.get(0);
+        assertEquals(event.tenantId(), TENANT_ID);
+        assertEquals(event.topic(), "jobs/job1/progress");
+        // second comes before first in lexicographical order by bucketing key
+        assertEquals(event.mqttTopicFilter(), first.mqttTopicFilter());
+        assertEquals(event.maxCount(), 1);
+    }
+
+    private static final class TreeMapKVReader implements IKVReader {
+        private final NavigableMap<ByteString, ByteString> data;
+        private TreeMapKVIterator lastIterator;
+
+        private TreeMapKVReader(NavigableMap<ByteString, ByteString> data) {
+            this.data = data;
+        }
+
+        @Override
+        public Boundary boundary() {
+            if (data.isEmpty()) {
+                return FULL_BOUNDARY;
+            }
+            ByteString start = data.firstKey();
+            ByteString end = upperBound(data.lastKey());
+            return toBoundary(start, end);
+        }
+
+        @Override
+        public long size(Boundary boundary) {
+            if (data.isEmpty()) {
+                return 0;
+            }
+            ByteString start = BoundaryUtil.startKey(boundary);
+            ByteString end = BoundaryUtil.endKey(boundary);
+            NavigableMap<ByteString, ByteString> sub = data;
+            if (start != null) {
+                sub = sub.tailMap(start, true);
+            }
+            if (end != null) {
+                sub = sub.headMap(end, false);
+            }
+            return sub.size();
+        }
+
+        @Override
+        public boolean exist(ByteString key) {
+            return data.containsKey(key);
+        }
+
+        @Override
+        public java.util.Optional<ByteString> get(ByteString key) {
+            return java.util.Optional.ofNullable(data.get(key));
+        }
+
+        @Override
+        public IKVIterator iterator() {
+            lastIterator = new TreeMapKVIterator(data);
+            return lastIterator;
+        }
+
+        @Override
+        public void refresh() {
+            // no-op for in-memory stub
+        }
+
+        TreeMapKVIterator lastIterator() {
+            return lastIterator;
+        }
+    }
+
+    private static final class TreeMapKVIterator implements IKVIterator {
+        private final NavigableMap<ByteString, ByteString> data;
+        private Map.Entry<ByteString, ByteString> current;
+        private int seekCount;
+        private int nextCount;
+
+        private TreeMapKVIterator(NavigableMap<ByteString, ByteString> data) {
+            this.data = data;
+        }
+
+        @Override
+        public ByteString key() {
+            if (current == null) {
+                throw new IllegalStateException("Iterator is not valid");
+            }
+            return current.getKey();
+        }
+
+        @Override
+        public ByteString value() {
+            if (current == null) {
+                throw new IllegalStateException("Iterator is not valid");
+            }
+            return current.getValue();
+        }
+
+        @Override
+        public boolean isValid() {
+            return current != null;
+        }
+
+        @Override
+        public void next() {
+            if (current == null) {
+                throw new IllegalStateException("Iterator is not valid");
+            }
+            current = data.higherEntry(current.getKey());
+            nextCount++;
+        }
+
+        @Override
+        public void prev() {
+            if (current == null) {
+                throw new IllegalStateException("Iterator is not valid");
+            }
+            current = data.lowerEntry(current.getKey());
+            nextCount++;
+        }
+
+        @Override
+        public void seekToFirst() {
+            current = data.firstEntry();
+            seekCount++;
+        }
+
+        @Override
+        public void seekToLast() {
+            current = data.lastEntry();
+            seekCount++;
+        }
+
+        @Override
+        public void seek(ByteString key) {
+            current = key == null ? data.firstEntry() : data.ceilingEntry(key);
+            seekCount++;
+        }
+
+        @Override
+        public void seekForPrev(ByteString key) {
+            current = key == null ? data.lastEntry() : data.floorEntry(key);
+            seekCount++;
+        }
+
+        int getSeekCount() {
+            return seekCount;
+        }
+
+        int getNextCount() {
+            return nextCount;
+        }
+    }
+
+    private static final class RecordingEventCollector implements IEventCollector {
+        private final List<Event<?>> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void report(Event<?> event) {
+            events.add((Event<?>) event.clone());
+        }
+
+        List<Event<?>> events() {
+            return new ArrayList<>(events);
+        }
+
+        <T extends Event<?>> List<T> eventsOfType(Class<T> type) {
+            List<T> filtered = new ArrayList<>();
+            for (Event<?> event : events) {
+                if (type.isInstance(event)) {
+                    filtered.add(type.cast(event));
+                }
+            }
+            return filtered;
+        }
+    }
+}

--- a/bifromq-dist/bifromq-dist-worker/src/test/java/org/apache/bifromq/dist/worker/schema/Matchings.java
+++ b/bifromq-dist/bifromq-dist-worker/src/test/java/org/apache/bifromq/dist/worker/schema/Matchings.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bifromq.dist.worker.schema;
+
+import static org.apache.bifromq.util.TopicConst.DELIMITER;
+import static org.apache.bifromq.util.TopicConst.ORDERED_SHARE;
+import static org.apache.bifromq.util.TopicConst.UNORDERED_SHARE;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.bifromq.type.RouteMatcher;
+
+/**
+ * Test Helper for creating NormalMatching & GroupMatching directly.
+ */
+public final class Matchings {
+    private Matchings() {
+    }
+
+    public static NormalMatching normalMatching(String tenantId,
+                                                String mqttTopicFilter,
+                                                int subBrokerId,
+                                                String receiverId,
+                                                String delivererKey,
+                                                long incarnation) {
+        RouteMatcher matcher = RouteMatcher.newBuilder()
+            .setType(RouteMatcher.Type.Normal)
+            .addAllFilterLevel(split(mqttTopicFilter))
+            .setMqttTopicFilter(mqttTopicFilter)
+            .build();
+        return new NormalMatching(tenantId,
+            matcher,
+            KVSchemaUtil.toReceiverUrl(subBrokerId, receiverId, delivererKey),
+            incarnation);
+    }
+
+    public static GroupMatching unorderedGroupMatching(String tenantId,
+                                                       String sharedTopicFilter,
+                                                       String group,
+                                                       Map<String, Long> members) {
+        RouteMatcher matcher = RouteMatcher.newBuilder()
+            .setType(RouteMatcher.Type.UnorderedShare)
+            .addAllFilterLevel(split(sharedTopicFilter))
+            .setGroup(group)
+            .setMqttTopicFilter(UNORDERED_SHARE + DELIMITER + group + DELIMITER + sharedTopicFilter)
+            .build();
+        return new GroupMatching(tenantId, matcher, members);
+    }
+
+    public static GroupMatching orderedGroupMatching(String tenantId,
+                                                     String sharedTopicFilter,
+                                                     String group,
+                                                     Map<String, Long> members) {
+        RouteMatcher matcher = RouteMatcher.newBuilder()
+            .setType(RouteMatcher.Type.OrderedShare)
+            .addAllFilterLevel(split(sharedTopicFilter))
+            .setGroup(group)
+            .setMqttTopicFilter(ORDERED_SHARE + DELIMITER + group + DELIMITER + sharedTopicFilter)
+            .build();
+        return new GroupMatching(tenantId, matcher, members);
+    }
+
+    public static String receiverUrl(int subBrokerId, String receiverId, String delivererKey) {
+        return KVSchemaUtil.toReceiverUrl(subBrokerId, receiverId, delivererKey);
+    }
+
+    private static List<String> split(String topicFilter) {
+        return Arrays.asList(topicFilter.split("/", -1));
+    }
+}

--- a/bifromq-metrics/src/main/java/org/apache/bifromq/metrics/ITenantMeter.java
+++ b/bifromq-metrics/src/main/java/org/apache/bifromq/metrics/ITenantMeter.java
@@ -14,13 +14,14 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License.    
+ * under the License.
  */
 
 package org.apache.bifromq.metrics;
 
 import io.micrometer.core.instrument.Timer;
 import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
 
 public interface ITenantMeter {
     String TAG_TENANT_ID = "tenantId";
@@ -35,6 +36,18 @@ public interface ITenantMeter {
 
     static void stopGauging(String tenantId, TenantMetric gaugeMetric, String... tagValuePair) {
         TenantGauges.stopGauging(tenantId, gaugeMetric, tagValuePair);
+    }
+
+    static <C> void counting(String tenantId,
+                             TenantMetric counterMetric,
+                             C ctr,
+                             ToDoubleFunction<C> supplier,
+                             String... tagValuePair) {
+        TenantFunctionCounters.counting(tenantId, counterMetric, ctr, supplier, tagValuePair);
+    }
+
+    static void stopCounting(String tenantId, TenantMetric counterMetric, String... tagValuePair) {
+        TenantFunctionCounters.stopCounting(tenantId, counterMetric, tagValuePair);
     }
 
     void recordCount(TenantMetric metric);

--- a/bifromq-metrics/src/main/java/org/apache/bifromq/metrics/TenantFunctionCounters.java
+++ b/bifromq-metrics/src/main/java/org/apache/bifromq/metrics/TenantFunctionCounters.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bifromq.metrics;
+
+import static org.apache.bifromq.metrics.ITenantMeter.TAG_TENANT_ID;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tags;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.ToDoubleFunction;
+
+class TenantFunctionCounters {
+    private static final ConcurrentMap<String, Map<TenantMetricKey, FunctionCounter>> TENANT_FUNCTION_COUNTERS = new ConcurrentHashMap<>();
+
+    static <C> void counting(String tenantId, TenantMetric counterMetric, C ctr, ToDoubleFunction<C> supplier,
+                             String... tagValuePair) {
+        assert counterMetric.meterType == Meter.Type.COUNTER && counterMetric.isFunction;
+        TENANT_FUNCTION_COUNTERS.compute(tenantId, (k, v) -> {
+            if (v == null) {
+                v = new HashMap<>();
+            }
+            Tags tags = Tags.of(tagValuePair);
+            v.computeIfAbsent(new TenantMetricKey(counterMetric, tags),
+                tenantMetricKey -> FunctionCounter.builder(counterMetric.metricName, ctr, supplier)
+                    .tags(tags.and(TAG_TENANT_ID, tenantId))
+                    .register(Metrics.globalRegistry));
+            return v;
+        });
+    }
+
+    static void stopCounting(String tenantId, TenantMetric counterMetric, String... tagValuePair) {
+        assert counterMetric.meterType == Meter.Type.COUNTER && counterMetric.isFunction;
+        TENANT_FUNCTION_COUNTERS.computeIfPresent(tenantId, (k, ctrMap) -> {
+            Tags tags = Tags.of(tagValuePair);
+            FunctionCounter functionCounter = ctrMap.remove(new TenantMetricKey(counterMetric, tags));
+            if (functionCounter != null) {
+                Metrics.globalRegistry.remove(functionCounter);
+            }
+            if (ctrMap.isEmpty()) {
+                return null;
+            }
+            return ctrMap;
+        });
+    }
+
+    private record TenantMetricKey(TenantMetric counterMetrics, Tags tags) {
+    }
+}

--- a/bifromq-metrics/src/main/java/org/apache/bifromq/metrics/TenantMetric.java
+++ b/bifromq-metrics/src/main/java/org/apache/bifromq/metrics/TenantMetric.java
@@ -14,7 +14,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License.    
+ * under the License.
  */
 
 package org.apache.bifromq.metrics;
@@ -72,7 +72,9 @@ public enum TenantMetric {
     MqttPersistentSubCountGauge("mqtt.psub.num.gauge", Meter.Type.GAUGE),
 
     MqttRouteCacheSize("mqtt.route.cache.size.gauge", Meter.Type.GAUGE),
-    MqttRouteCacheMissCount("mqtt.route.cache.miss.count", Meter.Type.COUNTER),
+    MqttRouteCacheHitCount("mqtt.route.cache.hit.count", Meter.Type.COUNTER, true),
+    MqttRouteCacheEvictCount("mqtt.route.cache.evict.count", Meter.Type.COUNTER, true),
+    MqttRouteCacheMissCount("mqtt.route.cache.miss.count", Meter.Type.COUNTER, true),
     // retain related
     MqttIngressRetainBytes("mqtt.ingress.retain.bytes", Meter.Type.DISTRIBUTION_SUMMARY),
     MqttRetainedBytes("mqtt.retained.bytes", Meter.Type.DISTRIBUTION_SUMMARY),
@@ -83,9 +85,16 @@ public enum TenantMetric {
 
     public final String metricName;
     public final Meter.Type meterType;
+    public final boolean isFunction;
 
     TenantMetric(String metricName, Meter.Type meterType) {
+        this(metricName, meterType, false);
+    }
+
+    TenantMetric(String metricName, Meter.Type meterType, boolean isFunction) {
+        assert !isFunction || meterType == Meter.Type.COUNTER;
         this.metricName = metricName;
         this.meterType = meterType;
+        this.isFunction = isFunction;
     }
 }

--- a/bifromq-plugin/bifromq-plugin-event-collector/src/main/java/org/apache/bifromq/plugin/eventcollector/distservice/GroupFanoutThrottled.java
+++ b/bifromq-plugin/bifromq-plugin-event-collector/src/main/java/org/apache/bifromq/plugin/eventcollector/distservice/GroupFanoutThrottled.java
@@ -33,6 +33,7 @@ import org.apache.bifromq.plugin.eventcollector.EventType;
 public final class GroupFanoutThrottled extends Event<GroupFanoutThrottled> {
     private String tenantId;
     private String topic;
+    private String mqttTopicFilter;
     private int maxCount;
 
     @Override

--- a/bifromq-plugin/bifromq-plugin-event-collector/src/main/java/org/apache/bifromq/plugin/eventcollector/distservice/PersistentFanoutThrottled.java
+++ b/bifromq-plugin/bifromq-plugin-event-collector/src/main/java/org/apache/bifromq/plugin/eventcollector/distservice/PersistentFanoutThrottled.java
@@ -33,6 +33,7 @@ import org.apache.bifromq.plugin.eventcollector.EventType;
 public final class PersistentFanoutThrottled extends Event<PersistentFanoutThrottled> {
     private String tenantId;
     private String topic;
+    private String mqttTopicFilter;
     private int maxCount;
 
     @Override


### PR DESCRIPTION
This PR addresses an issue where route additions or removals trigger invalidation of all cached entries matching the topic filter rules, potentially causing performance jitter when the topic filter contains wildcards.