### PR TITLE
Update lombok version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <guava.version>33.2.1-jre</guava.version>
         <jackson.version>2.18.1</jackson.version>
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
-        <lombok.version>1.18.34</lombok.version>
+        <lombok.version>1.18.42</lombok.version>
         <log4j.version>2.25.3</log4j.version>
         <micrometer.version>1.11.12</micrometer.version>
         <netty.version>4.1.127.Final</netty.version>


### PR DESCRIPTION
Java25 is an LTS version, currently the [Lombok version](https://github.com/projectlombok/lombok/issues/3859?utm_source=chatgpt.com) has compatibility issues for this new version. Upgrading the version can work for Java25 and Java17.