### PR TITLE
On back pressure rejected inbox commits, directly schedule a delayed retry.

### DIFF
--- a/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/handler/MQTTPersistentSessionHandler.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/handler/MQTTPersistentSessionHandler.java
@@ -406,14 +406,6 @@ public abstract class MQTTPersistentSessionHandler extends MQTTSessionHandler im
         }
     }
 
-    private void scheduleConfirmTimeout(long upToSeq) {
-        confirmTimeout = ctx.executor().schedule(() -> {
-            if (upToSeq < inboxConfirmedUpToSeq) {
-                confirmSendBuffer();
-            }
-        }, ThreadLocalRandom.current().nextLong(15, 45), TimeUnit.SECONDS);
-    }
-
     private void confirmQoS0() {
         if (qos0Confirming) {
             return;
@@ -503,9 +495,9 @@ public abstract class MQTTPersistentSessionHandler extends MQTTSessionHandler im
                         handleProtocolResponse(helper().onInboxTransientError(v.getCode().name()));
                     case BACK_PRESSURE_REJECTED -> {
                         inboxConfirming = false;
-                        if (upToSeq < inboxConfirmedUpToSeq) {
-                            scheduleConfirmTimeout(upToSeq);
-                        }
+                        // schedule confirm later
+                        confirmTimeout = ctx.executor()
+                            .schedule(this::confirmSendBuffer, ThreadLocalRandom.current().nextLong(15, 45), TimeUnit.SECONDS);
                     }
                     case TRY_LATER -> {
                         // try again with same version

--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTPersistentS2CPubTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTTPersistentS2CPubTest.java
@@ -246,6 +246,30 @@ public class MQTTPersistentS2CPubTest extends BaseMQTTTest {
     }
 
     @Test
+    public void retryCommitAfterBackPressure() {
+        mockAuthCheck(true);
+        when(inboxClient.commit(any()))
+            .thenReturn(CompletableFuture.completedFuture(
+                CommitReply.newBuilder().setCode(CommitReply.Code.BACK_PRESSURE_REJECTED).build()))
+            .thenReturn(CompletableFuture.completedFuture(
+                CommitReply.newBuilder().setCode(CommitReply.Code.OK).build()));
+
+        inboxFetchConsumer.accept(fetch(1, 128, AT_LEAST_ONCE));
+        channel.runPendingTasks();
+
+        MqttPublishMessage message = channel.readOutbound();
+        assertEquals(message.fixedHeader().qosLevel().value(), QoS.AT_LEAST_ONCE_VALUE);
+        channel.writeInbound(MQTTMessageUtils.pubAckMessage(message.variableHeader().packetId()));
+        channel.runPendingTasks();
+
+        channel.advanceTimeBy(45, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        channel.runPendingTasks();
+
+        verify(inboxClient, times(2)).commit(argThat(CommitRequest::hasSendBufferUpToSeq));
+    }
+
+    @Test
     public void fetchTryLater() {
         inboxFetchConsumer.accept(Fetched.newBuilder().setResult(Result.TRY_LATER).build());
         channel.advanceTimeBy(disconnectDelay, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Do not check the commit and confirm cursors  and schedule a delayed retry directly for this return code.