### PR TITLE
feat(plugin): initialize PluginManager eagerly at startup

### DIFF
--- a/build/build-bifromq-starter/pom.xml
+++ b/build/build-bifromq-starter/pom.xml
@@ -79,6 +79,12 @@
             <artifactId>bcprov-jdk18on</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>

--- a/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/StandaloneStarter.java
+++ b/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/StandaloneStarter.java
@@ -65,7 +65,8 @@ import org.apache.bifromq.starter.module.DistServiceModule;
 import org.apache.bifromq.starter.module.ExecutorsModule;
 import org.apache.bifromq.starter.module.InboxServiceModule;
 import org.apache.bifromq.starter.module.MQTTServiceModule;
-import org.apache.bifromq.starter.module.PluginModule;
+import org.apache.bifromq.starter.module.PluginExtensionModule;
+import org.apache.bifromq.starter.module.PluginRuntimeModule;
 import org.apache.bifromq.starter.module.RPCClientSSLContextModule;
 import org.apache.bifromq.starter.module.RPCServerBuilderModule;
 import org.apache.bifromq.starter.module.RetainServiceModule;
@@ -168,7 +169,8 @@ public class StandaloneStarter {
                 new RPCClientSSLContextModule(),
                 new CoreServiceModule(),
                 new RPCServerBuilderModule(),
-                new PluginModule(),
+                new PluginRuntimeModule(),
+                new PluginExtensionModule(),
                 new ExecutorsModule());
             Injector injector = Guice.createInjector(
                 new ConfigModule(config),

--- a/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/module/PluginExtensionModule.java
+++ b/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/module/PluginExtensionModule.java
@@ -14,7 +14,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License.    
+ * under the License.
  */
 
 package org.apache.bifromq.starter.module;
@@ -22,13 +22,11 @@ package org.apache.bifromq.starter.module;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import jakarta.inject.Singleton;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bifromq.inbox.client.IInboxClient;
 import org.apache.bifromq.mqtt.inbox.IMqttBrokerClient;
 import org.apache.bifromq.plugin.authprovider.AuthProviderManager;
 import org.apache.bifromq.plugin.clientbalancer.ClientBalancerManager;
 import org.apache.bifromq.plugin.eventcollector.EventCollectorManager;
-import org.apache.bifromq.plugin.manager.BifroMQPluginManager;
 import org.apache.bifromq.plugin.resourcethrottler.ResourceThrottlerManager;
 import org.apache.bifromq.plugin.settingprovider.SettingProviderManager;
 import org.apache.bifromq.plugin.subbroker.ISubBrokerManager;
@@ -36,34 +34,15 @@ import org.apache.bifromq.plugin.subbroker.SubBrokerManager;
 import org.apache.bifromq.starter.config.StandaloneConfig;
 import org.pf4j.PluginManager;
 
-@Slf4j
-public class PluginModule extends AbstractModule {
+public class PluginExtensionModule extends AbstractModule {
     @Override
     protected void configure() {
-        bind(PluginManager.class).toProvider(PluginManagerProvider.class).in(Singleton.class);
         bind(ISubBrokerManager.class).toProvider(SubBrokerManagerProvider.class).in(Singleton.class);
         bind(AuthProviderManager.class).toProvider(AuthProviderManagerProvider.class).in(Singleton.class);
         bind(EventCollectorManager.class).toProvider(EventCollectorManagerProvider.class).in(Singleton.class);
         bind(ResourceThrottlerManager.class).toProvider(ResourceThrottlerManagerProvider.class).in(Singleton.class);
         bind(SettingProviderManager.class).toProvider(SettingProviderManagerProvider.class).in(Singleton.class);
         bind(ClientBalancerManager.class).toProvider(ClientBalancerManagerProvider.class).in(Singleton.class);
-    }
-
-    private static class PluginManagerProvider extends SharedResourceProvider<BifroMQPluginManager> {
-
-        @Inject
-        private PluginManagerProvider(SharedResourcesHolder sharedResourcesHolder) {
-            super(sharedResourcesHolder);
-        }
-
-        @Override
-        public BifroMQPluginManager share() {
-            BifroMQPluginManager pluginMgr = new BifroMQPluginManager();
-            pluginMgr.getPlugins().forEach(
-                plugin -> log.info("Loaded plugin: {}@{}",
-                    plugin.getDescriptor().getPluginId(), plugin.getDescriptor().getVersion()));
-            return pluginMgr;
-        }
     }
 
     private static class AuthProviderManagerProvider extends SharedResourceProvider<AuthProviderManager> {
@@ -141,7 +120,6 @@ public class PluginModule extends AbstractModule {
             this.config = config;
             this.pluginManager = pluginManager;
         }
-
 
         @Override
         public SettingProviderManager share() {

--- a/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/module/PluginRuntimeModule.java
+++ b/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/module/PluginRuntimeModule.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bifromq.starter.module;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bifromq.plugin.manager.BifroMQPluginManager;
+import org.pf4j.PluginManager;
+
+@Slf4j
+public class PluginRuntimeModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(PluginManager.class).toProvider(PluginManagerProvider.class).asEagerSingleton();
+    }
+
+    private static class PluginManagerProvider extends SharedResourceProvider<BifroMQPluginManager> {
+        @Inject
+        private PluginManagerProvider(SharedResourcesHolder sharedResourcesHolder) {
+            super(sharedResourcesHolder);
+        }
+
+        @Override
+        public BifroMQPluginManager share() {
+            BifroMQPluginManager pluginMgr = new BifroMQPluginManager();
+            pluginMgr.getPlugins().forEach(
+                plugin -> log.info("Loaded plugin: {}@{}",
+                    plugin.getDescriptor().getPluginId(), plugin.getDescriptor().getVersion()));
+            return pluginMgr;
+        }
+    }
+}

--- a/build/build-bifromq-starter/src/test/java/org/apache/bifromq/starter/module/PluginModuleTest.java
+++ b/build/build-bifromq-starter/src/test/java/org/apache/bifromq/starter/module/PluginModuleTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bifromq.starter.module;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.google.inject.Binding;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scope;
+import com.google.inject.spi.BindingScopingVisitor;
+import com.google.inject.spi.Elements;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.bifromq.inbox.client.IInboxClient;
+import org.apache.bifromq.mqtt.inbox.IMqttBrokerClient;
+import org.apache.bifromq.plugin.settingprovider.ISettingProvider;
+import org.apache.bifromq.plugin.settingprovider.SettingProviderManager;
+import org.apache.bifromq.starter.config.StandaloneConfig;
+import org.pf4j.PluginManager;
+import org.testng.annotations.Test;
+
+public class PluginModuleTest {
+    @Test
+    public void pluginRuntimeBindsPluginManagerAsEagerSingleton() {
+        AtomicBoolean eagerSingleton = new AtomicBoolean();
+        Binding<?> pluginManagerBinding = Elements.getElements(new PluginRuntimeModule()).stream()
+            .filter(Binding.class::isInstance)
+            .map(Binding.class::cast)
+            .filter(binding -> binding.getKey().getTypeLiteral().getRawType().equals(PluginManager.class))
+            .findFirst()
+            .orElse(null);
+
+        assertNotNull(pluginManagerBinding);
+        pluginManagerBinding.acceptScopingVisitor(new BindingScopingVisitor<Void>() {
+            @Override
+            public Void visitEagerSingleton() {
+                eagerSingleton.set(true);
+                return null;
+            }
+
+            @Override
+            public Void visitScope(Scope scope) {
+                return null;
+            }
+
+            @Override
+            public Void visitScopeAnnotation(Class<? extends Annotation> scopeAnnotation) {
+                return null;
+            }
+
+            @Override
+            public Void visitNoScoping() {
+                return null;
+            }
+        });
+
+        assertTrue(eagerSingleton.get());
+    }
+
+    @Test
+    public void pluginExtensionManagersAreLazy() {
+        PluginManager pluginManager = mock(PluginManager.class);
+
+        Guice.createInjector(
+            binder -> {
+                binder.bind(StandaloneConfig.class).toInstance(new StandaloneConfig());
+                binder.bind(PluginManager.class).toInstance(pluginManager);
+                binder.bind(SharedResourcesHolder.class).toInstance(sharedResourcesHolder());
+                binder.bind(IMqttBrokerClient.class).toInstance(mock(IMqttBrokerClient.class));
+                binder.bind(IInboxClient.class).toInstance(mock(IInboxClient.class));
+            },
+            new PluginExtensionModule());
+
+        verifyNoInteractions(pluginManager);
+    }
+
+    @Test
+    public void settingProviderLoadsExtensionWhenRequested() {
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(pluginManager.getExtensions(ISettingProvider.class)).thenReturn(Collections.emptyList());
+        Injector injector = Guice.createInjector(
+            binder -> {
+                binder.bind(StandaloneConfig.class).toInstance(new StandaloneConfig());
+                binder.bind(PluginManager.class).toInstance(pluginManager);
+                binder.bind(SharedResourcesHolder.class).toInstance(sharedResourcesHolder());
+                binder.bind(IMqttBrokerClient.class).toInstance(mock(IMqttBrokerClient.class));
+                binder.bind(IInboxClient.class).toInstance(mock(IInboxClient.class));
+            },
+            new PluginExtensionModule());
+
+        injector.getInstance(SettingProviderManager.class);
+
+        verify(pluginManager).getExtensions(ISettingProvider.class);
+    }
+
+    private SharedResourcesHolder sharedResourcesHolder() {
+        SharedResourcesHolder holder = mock(SharedResourcesHolder.class);
+        when(holder.add(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        return holder;
+    }
+}


### PR DESCRIPTION
Previously, PluginManager was bound in the same Guice module as extension managers (e.g., AuthProviderManager, EventCollectorManager), causing it to be initialized lazily only when those managers were accessed. This could lead to PluginManager never being initialized if extensions were unused.

This change decouples PluginManager initialization from extension managers, ensuring it is created during application bootstrap regardless of extension usage.

Fixes #248