### PR TITLE
[MQTT] Stop QoS0 push from refreshing keepalive

### DIFF
--- a/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/handler/MQTTSessionHandler.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/handler/MQTTSessionHandler.java
@@ -1063,7 +1063,6 @@ public abstract class MQTTSessionHandler extends MQTTMessageHandler implements I
         write(pubMsg).addListener(f -> {
             memUsage.addAndGet(-msgSize);
             if (f.isSuccess()) {
-                lastActiveAtNanos = sessionCtx.nanoTime();
                 if (settings.debugMode) {
                     eventCollector.report(getLocal(QoS0Pushed.class)
                         .isRetain(msg.isRetain())

--- a/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTT3TransientSessionHandlerTest.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/test/java/org/apache/bifromq/mqtt/handler/v3/MQTT3TransientSessionHandlerTest.java
@@ -24,6 +24,7 @@ import static io.netty.handler.codec.mqtt.MqttMessageType.PUBREL;
 import static org.apache.bifromq.mqtt.handler.MQTTSessionIdUtil.userSessionId;
 import static org.apache.bifromq.plugin.eventcollector.EventType.DISCARD;
 import static org.apache.bifromq.plugin.eventcollector.EventType.EXCEED_RECEIVING_LIMIT;
+import static org.apache.bifromq.plugin.eventcollector.EventType.IDLE;
 import static org.apache.bifromq.plugin.eventcollector.EventType.INVALID_TOPIC;
 import static org.apache.bifromq.plugin.eventcollector.EventType.INVALID_TOPIC_FILTER;
 import static org.apache.bifromq.plugin.eventcollector.EventType.MALFORMED_TOPIC;
@@ -726,6 +727,35 @@ public class MQTT3TransientSessionHandlerTest extends BaseSessionHandlerTest {
             assertEquals(message.variableHeader().topicName(), topic);
         }
         verifyEvent(MQTT_SESSION_START, QOS0_PUSHED, QOS0_PUSHED, QOS0_PUSHED, QOS0_PUSHED, QOS0_PUSHED);
+    }
+
+    @Test
+    public void qos0PubDoesNotRefreshSessionKeepAlive() {
+        mockCheckPermission(true);
+        mockDistMatch(true);
+        transientSessionHandler.subscribe(System.nanoTime(), topicFilter, QoS.AT_MOST_ONCE);
+        channel.runPendingTasks();
+        ArgumentCaptor<Long> longCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(localDistService).match(anyLong(), eq(topicFilter), longCaptor.capture(), any());
+
+        testTicker.advanceTimeBy(100, TimeUnit.SECONDS);
+        channel.advanceTimeBy(100, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        assertTrue(channel.isActive());
+
+        transientSessionHandler.publish(s2cMessageList(topic, 1, QoS.AT_MOST_ONCE),
+            Collections.singleton(new IMQTTTransientSession.MatchedTopicFilter(topicFilter, longCaptor.getValue())));
+        channel.runPendingTasks();
+        MqttPublishMessage message = channel.readOutbound();
+        assertEquals(message.fixedHeader().qosLevel().value(), QoS.AT_MOST_ONCE_VALUE);
+        assertEquals(message.variableHeader().topicName(), topic);
+
+        testTicker.advanceTimeBy(81, TimeUnit.SECONDS);
+        channel.advanceTimeBy(81, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertFalse(channel.isActive());
+        verifyEvent(MQTT_SESSION_START, QOS0_PUSHED, IDLE);
     }
 
     @Test


### PR DESCRIPTION
Fixes #260
QoS0 outbound PUBLISH refreshes MQTT keepalive idle timer and delays LWT for half-open clients

## Summary

Stop outbound QoS0 PUBLISH write success from refreshing the MQTT session keepalive activity timestamp.

## Motivation

When a client becomes half-open or loses power, the broker may still keep sending QoS0 downstream PUBLISH packets to that connection. Previously, successful QoS0 downstream writes updated `lastActiveAtNanos`, which could postpone keepalive idle detection and delay LWT publication even though the client no longer sends MQTT packets.

## Changes

- Remove `lastActiveAtNanos = sessionCtx.nanoTime()` from the QoS0 downstream write-success path.
- Add a regression test to verify QoS0 downstream PUBLISH does not refresh MQTT session keepalive.

## Tests

```powershell
.\mvnw.cmd -pl bifromq-mqtt/bifromq-mqtt-server -Dtest=MQTT3TransientSessionHandlerTest#qos0PubDoesNotRefreshSessionKeepAlive test
.\mvnw.cmd -pl bifromq-mqtt/bifromq-mqtt-server -Dtest=MQTT3TransientSessionHandlerTest test