### PR TITLE
Set Content-Type for demo plugin metrics endpoint

### DIFF
--- a/build/build-plugin-demo/src/main/java/org/apache/bifromq/demo/plugin/DemoPlugin.java
+++ b/build/build-plugin-demo/src/main/java/org/apache/bifromq/demo/plugin/DemoPlugin.java
@@ -29,9 +29,11 @@ import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bifromq.plugin.BifroMQPlugin;
@@ -79,10 +81,12 @@ public class DemoPlugin extends BifroMQPlugin<DemoPluginContext> {
         try {
             prometheusExportServer = HttpServer.create(new InetSocketAddress(exportPort), 0);
             prometheusExportServer.createContext(getContext(), httpExchange -> {
-                String response = registry.scrape();
-                httpExchange.sendResponseHeaders(200, response.getBytes().length);
+                byte[] response = registry.scrape().getBytes(StandardCharsets.UTF_8);
+                httpExchange.getResponseHeaders()
+                    .set("Content-Type", TextFormat.CONTENT_TYPE_004);
+                httpExchange.sendResponseHeaders(200, response.length);
                 try (OutputStream os = httpExchange.getResponseBody()) {
-                    os.write(response.getBytes());
+                    os.write(response);
                 }
             });
             serverThread = new Thread(prometheusExportServer::start);


### PR DESCRIPTION
## Background

I ran into this issue after Prometheus was upgraded in an environment at work.

Prometheus could reach the demo plugin metrics endpoint, but the scrape target
was marked as down with the following error:

```text
non-compliant scrape target sending blank content-type and no fallback_scrape_protocol specified for target
```

The response body contained valid metrics. The scrape failed because the demo
plugin did not set a `Content-Type` response header, and Prometheus did not have
a `fallback_scrape_protocol` configured for the target.

Starting with Prometheus 3.0, scrape targets must return a valid and supported
`Content-Type`. Prometheus 2.x previously treated a missing or unrecognized
Content-Type as Prometheus text format by default.

Reference:

https://prometheus.io/docs/prometheus/latest/migration/#scrape-protocols

## Change

Set the metrics response header to the Prometheus text exposition format:

```http
Content-Type: text/plain; version=0.0.4; charset=utf-8
```

The header is set using `TextFormat.CONTENT_TYPE_004`, which matches the output
format produced by `PrometheusMeterRegistry.scrape()`.

The response body is also encoded explicitly as UTF-8. The encoded byte array
is reused when calculating `Content-Length` and writing the response body,
avoiding repeated conversion with the platform default charset.

## Compatibility

Prometheus text format 0.0.4 has been supported since Prometheus 0.4.0.

This change fixes metrics scraping with Prometheus 3.0 and later without
requiring `fallback_scrape_protocol`, while remaining compatible with older
Prometheus versions, including Prometheus 2.x.

## Testing

Built the demo plugin with:

```bash
./mvnw -pl build/build-plugin-demo -am package -DskipTests
```

Started the plugin on an isolated port and confirmed that the metrics endpoint
returns HTTP 200 with the expected header:

```http
Content-Type: text/plain; version=0.0.4; charset=utf-8
```
