### PR TITLE
Make forwarded client address handling configurable

### DIFF
--- a/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/ConnListenerBuilder.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/ConnListenerBuilder.java
@@ -35,6 +35,7 @@ public abstract class ConnListenerBuilder<C extends ConnListenerBuilder<C>> {
     private final MQTTBrokerBuilder serverBuilder;
     protected String host;
     protected int port;
+    protected boolean enableProxyProtocol = true;
 
     ConnListenerBuilder(MQTTBrokerBuilder builder) {
         serverBuilder = builder;
@@ -60,6 +61,11 @@ public abstract class ConnListenerBuilder<C extends ConnListenerBuilder<C>> {
     public C port(int port) {
         Preconditions.checkArgument(port > 0, "port");
         this.port = port;
+        return thisT();
+    }
+
+    public C enableProxyProtocol(boolean enableProxyProtocol) {
+        this.enableProxyProtocol = enableProxyProtocol;
         return thisT();
     }
 
@@ -120,6 +126,7 @@ public abstract class ConnListenerBuilder<C extends ConnListenerBuilder<C>> {
 
     public static final class WSConnListenerBuilder extends ConnListenerBuilder<WSConnListenerBuilder> {
         private String path = "mqtt";
+        private boolean enableClientAddressHeader = true;
 
         WSConnListenerBuilder(MQTTBrokerBuilder builder) {
             super(builder);
@@ -133,10 +140,20 @@ public abstract class ConnListenerBuilder<C extends ConnListenerBuilder<C>> {
             this.path = path;
             return this;
         }
+
+        public WSConnListenerBuilder enableClientAddressHeader(boolean enableClientAddressHeader) {
+            this.enableClientAddressHeader = enableClientAddressHeader;
+            return this;
+        }
+
+        public boolean clientAddressHeaderEnabled() {
+            return enableClientAddressHeader;
+        }
     }
 
     public static final class WSSConnListenerBuilder extends SecuredConnListenerBuilder<WSSConnListenerBuilder> {
         private String path;
+        private boolean enableClientAddressHeader = true;
 
         WSSConnListenerBuilder(MQTTBrokerBuilder builder) {
             super(builder);
@@ -149,6 +166,15 @@ public abstract class ConnListenerBuilder<C extends ConnListenerBuilder<C>> {
         public WSSConnListenerBuilder path(String path) {
             this.path = path;
             return this;
+        }
+
+        public WSSConnListenerBuilder enableClientAddressHeader(boolean enableClientAddressHeader) {
+            this.enableClientAddressHeader = enableClientAddressHeader;
+            return this;
+        }
+
+        public boolean clientAddressHeaderEnabled() {
+            return enableClientAddressHeader;
         }
     }
 }

--- a/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/MQTTBroker.java
+++ b/bifromq-mqtt/bifromq-mqtt-server/src/main/java/org/apache/bifromq/mqtt/MQTTBroker.java
@@ -170,7 +170,7 @@ class MQTTBroker implements IMQTTBroker {
     }
 
     private ChannelFuture bindTCPChannel(ConnListenerBuilder.TCPConnListenerBuilder connBuilder) {
-        return buildChannel(connBuilder, new MQTTChannelInitializer() {
+        return buildChannel(connBuilder, new MQTTChannelInitializer(connBuilder.enableProxyProtocol) {
             @Override
             protected void initChannel(SocketChannel ch) {
                 super.initChannel(ch);
@@ -194,7 +194,7 @@ class MQTTBroker implements IMQTTBroker {
     }
 
     private ChannelFuture bindTLSChannel(ConnListenerBuilder.TLSConnListenerBuilder connBuilder) {
-        return buildChannel(connBuilder, new MQTTChannelInitializer() {
+        return buildChannel(connBuilder, new MQTTChannelInitializer(connBuilder.enableProxyProtocol) {
             @Override
             protected void initChannel(SocketChannel ch) {
                 super.initChannel(ch);
@@ -219,7 +219,7 @@ class MQTTBroker implements IMQTTBroker {
     }
 
     private ChannelFuture bindWSChannel(ConnListenerBuilder.WSConnListenerBuilder connBuilder) {
-        return buildChannel(connBuilder, new MQTTChannelInitializer() {
+        return buildChannel(connBuilder, new MQTTChannelInitializer(connBuilder.enableProxyProtocol) {
             @Override
             protected void initChannel(SocketChannel ch) {
                 super.initChannel(ch);
@@ -229,7 +229,9 @@ class MQTTBroker implements IMQTTBroker {
                         new ChannelTrafficShapingHandler(builder.writeLimit, builder.readLimit));
                     p.addLast("httpEncoder", new HttpResponseEncoder());
                     p.addLast("httpDecoder", new HttpRequestDecoder());
-                    p.addLast("remoteAddr", new ClientAddrHandler());
+                    if (connBuilder.clientAddressHeaderEnabled()) {
+                        p.addLast("remoteAddr", new ClientAddrHandler());
+                    }
                     p.addLast("aggregator", new HttpObjectAggregator(65536));
                     p.addLast("webSocketOnly", new WebSocketOnlyHandler(connBuilder.path()));
                     p.addLast("webSocketHandler", new WebSocketServerProtocolHandler(connBuilder.path(),
@@ -242,7 +244,7 @@ class MQTTBroker implements IMQTTBroker {
     }
 
     private ChannelFuture bindWSSChannel(ConnListenerBuilder.WSSConnListenerBuilder connBuilder) {
-        return buildChannel(connBuilder, new MQTTChannelInitializer() {
+        return buildChannel(connBuilder, new MQTTChannelInitializer(connBuilder.enableProxyProtocol) {
             @Override
             protected void initChannel(SocketChannel ch) {
                 super.initChannel(ch);
@@ -253,7 +255,9 @@ class MQTTBroker implements IMQTTBroker {
                         new ChannelTrafficShapingHandler(builder.writeLimit, builder.readLimit));
                     p.addLast("httpEncoder", new HttpResponseEncoder());
                     p.addLast("httpDecoder", new HttpRequestDecoder());
-                    p.addLast(ClientAddrHandler.class.getName(), new ClientAddrHandler());
+                    if (connBuilder.clientAddressHeaderEnabled()) {
+                        p.addLast(ClientAddrHandler.class.getName(), new ClientAddrHandler());
+                    }
                     p.addLast("aggregator", new HttpObjectAggregator(65536));
                     p.addLast("webSocketOnly", new WebSocketOnlyHandler(connBuilder.path()));
                     p.addLast("webSocketHandler", new WebSocketServerProtocolHandler(connBuilder.path(),
@@ -279,14 +283,22 @@ class MQTTBroker implements IMQTTBroker {
     }
 
     private abstract static class MQTTChannelInitializer extends ChannelInitializer<SocketChannel> {
+        private final boolean enableProxyProtocol;
+
+        private MQTTChannelInitializer(boolean enableProxyProtocol) {
+            this.enableProxyProtocol = enableProxyProtocol;
+        }
+
         @Override
         protected void initChannel(SocketChannel ch) {
-            ChannelPipeline pipeline = ch.pipeline();
-            // handler for proxy protocol v1 and v2
-            pipeline
-                .addLast(ProxyProtocolDetector.class.getName(), new ProxyProtocolDetector())
-                .addLast(HAProxyMessageDecoder.class.getName(), new HAProxyMessageDecoder())
-                .addLast(ProxyProtocolHandler.class.getName(), new ProxyProtocolHandler());
+            if (enableProxyProtocol) {
+                ChannelPipeline pipeline = ch.pipeline();
+                // handler for proxy protocol v1 and v2
+                pipeline
+                    .addLast(ProxyProtocolDetector.class.getName(), new ProxyProtocolDetector())
+                    .addLast(HAProxyMessageDecoder.class.getName(), new HAProxyMessageDecoder())
+                    .addLast(ProxyProtocolHandler.class.getName(), new ProxyProtocolHandler());
+            }
         }
     }
 }

--- a/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/config/model/mqtt/listener/TCPListenerConfig.java
+++ b/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/config/model/mqtt/listener/TCPListenerConfig.java
@@ -28,4 +28,5 @@ public class TCPListenerConfig {
     private boolean enable = true;
     private String host = "0.0.0.0";
     private int port = 1883;
+    private boolean enableProxyProtocol = true;
 }

--- a/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/config/model/mqtt/listener/TLSListenerConfig.java
+++ b/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/config/model/mqtt/listener/TLSListenerConfig.java
@@ -30,4 +30,5 @@ public class TLSListenerConfig {
     private String host;
     private int port = 1884;
     private ServerSSLContextConfig sslConfig;
+    private boolean enableProxyProtocol = true;
 }

--- a/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/config/model/mqtt/listener/WSListenerConfig.java
+++ b/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/config/model/mqtt/listener/WSListenerConfig.java
@@ -29,4 +29,6 @@ public class WSListenerConfig {
     private String host;
     private int port = 8080;
     private String wsPath = "/mqtt";
+    private boolean enableProxyProtocol = true;
+    private boolean enableClientAddressHeader = true;
 }

--- a/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/config/model/mqtt/listener/WSSListenerConfig.java
+++ b/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/config/model/mqtt/listener/WSSListenerConfig.java
@@ -31,4 +31,6 @@ public class WSSListenerConfig {
     private int port = 8443;
     private String wsPath = "/mqtt";
     private ServerSSLContextConfig sslConfig;
+    private boolean enableProxyProtocol = true;
+    private boolean enableClientAddressHeader = true;
 }

--- a/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/module/MQTTServiceModule.java
+++ b/build/build-bifromq-starter/src/main/java/org/apache/bifromq/starter/module/MQTTServiceModule.java
@@ -89,12 +89,14 @@ public class MQTTServiceModule extends AbstractModule {
                 brokerBuilder.buildTcpConnListener()
                     .host(serverConfig.getTcpListener().getHost())
                     .port(serverConfig.getTcpListener().getPort())
+                    .enableProxyProtocol(serverConfig.getTcpListener().isEnableProxyProtocol())
                     .buildListener();
             }
             if (serverConfig.getTlsListener().isEnable()) {
                 brokerBuilder.buildTLSConnListener()
                     .host(serverConfig.getTlsListener().getHost())
                     .port(serverConfig.getTlsListener().getPort())
+                    .enableProxyProtocol(serverConfig.getTlsListener().isEnableProxyProtocol())
                     .sslContext(buildServerSslContext(serverConfig.getTlsListener().getSslConfig()))
                     .buildListener();
             }
@@ -103,6 +105,8 @@ public class MQTTServiceModule extends AbstractModule {
                     .host(serverConfig.getWsListener().getHost())
                     .port(serverConfig.getWsListener().getPort())
                     .path(serverConfig.getWsListener().getWsPath())
+                    .enableProxyProtocol(serverConfig.getWsListener().isEnableProxyProtocol())
+                    .enableClientAddressHeader(serverConfig.getWsListener().isEnableClientAddressHeader())
                     .buildListener();
             }
             if (serverConfig.getWssListener().isEnable()) {
@@ -110,6 +114,8 @@ public class MQTTServiceModule extends AbstractModule {
                     .host(serverConfig.getWssListener().getHost())
                     .port(serverConfig.getWssListener().getPort())
                     .path(serverConfig.getWssListener().getWsPath())
+                    .enableProxyProtocol(serverConfig.getWssListener().isEnableProxyProtocol())
+                    .enableClientAddressHeader(serverConfig.getWssListener().isEnableClientAddressHeader())
                     .sslContext(buildServerSslContext(serverConfig.getWssListener().getSslConfig()))
                     .buildListener();
             }


### PR DESCRIPTION
## Summary

Make forwarded client address handling configurable per MQTT listener.

- Add `enableProxyProtocol` for TCP, TLS, WS, and WSS listeners.
- Add `enableClientAddressHeader` for WS and WSS listeners.
- Keep both options enabled by default to preserve existing load balancer deployments.
- Allow deployments with different network boundaries to disable either mechanism explicitly.